### PR TITLE
Allow exactly two decimal places in an offer

### DIFF
--- a/app/views/offers/_form.html.erb
+++ b/app/views/offers/_form.html.erb
@@ -11,7 +11,7 @@
 
             <div class="form-group">
                 <%= f.label :price %>
-                <%= f.number_field :price, class: "form-control", min: 0 %>
+                <%= f.number_field :price, class: "form-control", min: 0, step: "0.01" %>
             </div>
         </div>
 

--- a/test/system/offers_test.rb
+++ b/test/system/offers_test.rb
@@ -34,10 +34,29 @@ class OffersTest < ApplicationSystemTestCase
     assert(page.has_link?('Submit offer'))
     click_link('Submit offer')
 
-    fill_in('offer[price]', with: '5.00')
+    fill_in('offer[price]', with: '5.12')
     click_link_or_button('Submit')
 
     assert(page.has_text?('Created successfully'))
+  end
+
+  def test_participant_cannot_submit_an_offer_with_3_or_more_decimal_places
+    sign_in(@user)
+    visit auction_path(@valid_auction_with_no_offers)
+
+    assert(page.has_link?('Submit offer'))
+    click_link('Submit offer')
+
+    fill_in('offer[price]', with: '5.121')
+
+    # Check in-browser validation
+    validation_message = find("#offer_price").native.attribute("validationMessage")
+    assert_equal("Please enter a valid value. The two nearest valid values are 5.12 and 5.13.",
+                 validation_message)
+
+    assert_no_changes('Offer.count') do
+      click_link_or_button('Submit')
+    end
   end
 
   def test_participant_can_update_an_offer

--- a/test/system/offers_test.rb
+++ b/test/system/offers_test.rb
@@ -65,7 +65,7 @@ class OffersTest < ApplicationSystemTestCase
 
     click_link_or_button('Edit')
 
-    fill_in('offer[price]', with: '5.00')
+    fill_in('offer[price]', with: '5')
     click_link_or_button('Submit')
 
     assert(page.has_text?('Updated successfully'))


### PR DESCRIPTION
An error came up on staging, this should ensure that:

* You cannot enter more than 2 decimal places in price for your offer.
* You can still use integers (5), as well as decimals (6.11)