### PR TITLE
Add jobs to crontab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 # Configuration files
 /config/database.yml
 /config/customization.yml
+/config/schedule.rb
 /config/environments/development.rb
 /config/payment_methods/*
 !/config/payment_methods/.keep

--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ gem 'kaminari'
 gem 'money'
 gem 'omniauth-tara', github: 'internetee/omniauth-tara'
 gem 'recaptcha'
+gem 'whenever', require: false
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,7 @@ GEM
     chromedriver-helper (2.1.0)
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
+    chronic (0.10.2)
     coderay (1.1.2)
     concurrent-ruby (1.1.4)
     crass (1.0.4)
@@ -267,6 +268,8 @@ GEM
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
+    whenever (0.10.0)
+      chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
 
@@ -298,6 +301,7 @@ DEPENDENCIES
   turbolinks (~> 5)
   web-console (>= 3.3.0)
   webpacker (~> 3.0)
+  whenever
 
 RUBY VERSION
    ruby 2.5.3p105

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Software for managing TLD domain auctions
 
 1. Run `bin/setup`
 2. Configure database in `config/database.yml` according to your needs
-3. Run `bundle exec rake db:setup`
+3. Adjust configuration variables in `config/customization.yml`.
+4. Adjust schedule in `config/schedule.rb`, and then run `whenever --update-crontab` to write the schedule to crontab.
+5. Run `bundle exec rake db:setup`
 
 ## Default user account
 

--- a/bin/setup
+++ b/bin/setup
@@ -36,6 +36,11 @@ chdir APP_ROOT do
     puts "\n== config/customization.yml ready for customization =="
   end
 
+  unless File.exists?('config/schedule.rb')
+    cp 'config/schedule.rb.sample', 'config/schedule.rb'
+    puts "\n== config/schedule.rb ready for customization =="
+  end
+
   puts "\n== Removing old logs and tempfiles =="
   system! 'bin/rails log:clear tmp:clear'
 end

--- a/config/schedule.rb.sample
+++ b/config/schedule.rb.sample
@@ -1,0 +1,20 @@
+# Use this file to easily define all of your cron jobs.
+#
+# It's helpful, but not entirely necessary to understand cron before proceeding.
+# http://en.wikipedia.org/wiki/Cron
+
+# Example:
+#
+# set :output, "/path/to/my/cron_log.log"
+#
+# every 2.hours do
+#   command "/usr/bin/some_great_command"
+#   runner "MyModel.some_method"
+#   rake "some:great:rake:task"
+# end
+#
+# every 4.days do
+#   runner "AnotherModel.prune_old_records"
+# end
+
+# Learn more: http://github.com/javan/whenever

--- a/config/schedule.rb.sample
+++ b/config/schedule.rb.sample
@@ -3,18 +3,23 @@
 # It's helpful, but not entirely necessary to understand cron before proceeding.
 # http://en.wikipedia.org/wiki/Cron
 
-# Example:
-#
-# set :output, "/path/to/my/cron_log.log"
-#
-# every 2.hours do
-#   command "/usr/bin/some_great_command"
-#   runner "MyModel.some_method"
-#   rake "some:great:rake:task"
-# end
-#
-# every 4.days do
-#   runner "AnotherModel.prune_old_records"
-# end
+every 2.hours do
+  runner "ResultCreationJob.perform_later"
+  runner "ResultStatusUpdateJob.perform_later"
+  runner "InvoiceCreationJob.perform_later"
+end
+
+every 1.day, at: '22:00' do
+  runner "AuctionCreationJob.perform_later"
+end
+
+every 1.day, at: '23:55' do
+  runner "AuctionCreationJob.perform_later"
+  runner "DomainRegistrationCheckJob.perform_later"
+end
+
+every 1.day, at: '00:15' do
+  runner "InvoiceCancellationJob.perform_later"
+end
 
 # Learn more: http://github.com/javan/whenever


### PR DESCRIPTION
This adds whenever gem that allows us to use crontab to run arbitrary Ruby code. It is not required for staging environment. In contrast to Registry, the actual schedule should not live inside this repository, as it will allow us to change it more frequently and differ the schedules between environment. 

There is an example `schedule.rb` file that is copied over on new environment setup. As with customization.yml file, it should live inside our deployment scripts.

FYI @teadur , @ratM1n 