### PR TITLE
Add API for currently getting auctions

### DIFF
--- a/app/views/auctions/index.json.jbuilder
+++ b/app/views/auctions/index.json.jbuilder
@@ -1,0 +1,5 @@
+json.array! @auctions do |auction|
+  json.domain_name auction.domain_name
+  json.starts_at auction.starts_at.utc
+  json.ends_at auction.ends_at.utc
+end

--- a/test/integration/api_auctions_list_test.rb
+++ b/test/integration/api_auctions_list_test.rb
@@ -1,0 +1,37 @@
+require 'test_helper'
+
+class ApiAuctionsListTest < ActionDispatch::IntegrationTest
+  def setup
+    super
+
+    travel_to Time.parse('2010-07-05 10:30 +0000')
+  end
+
+  def teardown
+    super
+
+    travel_back
+  end
+
+  def test_can_get_a_list_of_current_auctions_as_json
+    get(auctions_path, headers: { 'Accept': 'application/json' })
+    response_json = JSON.parse(response.body)
+
+    assert_equal(response_json.count, 4)
+
+    response_json.each do |item|
+      assert(item.has_key?('domain_name'))
+      assert(item.has_key?('starts_at'))
+      assert(item.has_key?('ends_at'))
+    end
+
+    expected_domains = ['with-offers.test', 'no-offers.test', 'with-invoice.test', 'orphaned.test']
+    assert_equal(expected_domains.to_set, response_json.map { |e| e['domain_name'] }.to_set)
+  end
+
+  def test_cannot_get_a_list_of_current_auctions_as_xml
+    assert_raises ActionController::UnknownFormat do
+      get(auctions_path, headers: { 'Accept': 'application/xml' })
+    end
+  end
+end


### PR DESCRIPTION
Adds handling of GET /auctions as JSON with no authentication. Returns an array of auction objects:

```
[{"domain_name": "orphaned.test", 
 "starts_at": "2010-07-05T10:30:00.000Z", 
 "ends_at": "2010-07-06T10:30:00.000Z"}]
```
Because it is not our place to decide what timezone client is in, returns only UTC.
