### PR TITLE
Make search action reload-friendly

### DIFF
--- a/app/controllers/auctions_controller.rb
+++ b/app/controllers/auctions_controller.rb
@@ -21,6 +21,7 @@ class AuctionsController < ApplicationController
     domain_name = search_params[:domain_name]
 
     @auctions = Auction.where('domain_name ILIKE ?', "#{domain_name}%")
+                       .includes(:offers)
                        .accessible_by(current_ability)
                        .page(1)
   end

--- a/app/views/admin/auctions/index.html.erb
+++ b/app/views/admin/auctions/index.html.erb
@@ -7,7 +7,7 @@
 <div class="features-grid top narrow grey">
     <div class="ui search">
         <div class="ui massive input icon">
-            <%= form_with(url: search_admin_auctions_path, local: true) do |f| %>
+            <%= form_with(url: search_admin_auctions_path, local: true, method: :get) do |f| %>
                 <div class="ui input icon">
                     <%= f.text_field :domain_name, placeholder: t('search_by_domain_name') %>
                 </div>

--- a/app/views/admin/auctions/search.html.erb
+++ b/app/views/admin/auctions/search.html.erb
@@ -7,7 +7,7 @@
 <div class="features-grid top narrow grey">
     <div class="ui search">
         <div class="ui massive input icon">
-            <%= form_with(url: search_admin_auctions_path, local: true) do |f| %>
+            <%= form_with(url: search_admin_auctions_path, local: true, method: :get) do |f| %>
                 <div class="ui input icon">
                     <%= f.text_field :domain_name, placeholder: t('search_by_domain_name') %>
                 </div>

--- a/app/views/admin/invoices/index.html.erb
+++ b/app/views/admin/invoices/index.html.erb
@@ -7,7 +7,7 @@
 <div class="features-grid top narrow grey">
     <div class="ui search">
         <div class="ui massive input icon">
-            <%= form_with(url: search_admin_invoices_path, local: true) do |f| %>
+            <%= form_with(url: search_admin_invoices_path, local: true, method: :get) do |f| %>
                 <div class="ui input icon">
                     <%= f.text_field :email, placeholder: t('search_by_email') %>
                 </div>

--- a/app/views/admin/invoices/search.html.erb
+++ b/app/views/admin/invoices/search.html.erb
@@ -7,7 +7,7 @@
 <div class="features-grid top narrow grey">
     <div class="ui search">
         <div class="ui massive input icon">
-            <%= form_with(url: search_admin_invoices_path, local: true) do |f| %>
+            <%= form_with(url: search_admin_invoices_path, local: true, method: :get) do |f| %>
                 <div class="ui input icon">
                     <%= f.text_field :email, placeholder: t('search_by_email') %>
                 </div>

--- a/app/views/admin/results/index.html.erb
+++ b/app/views/admin/results/index.html.erb
@@ -7,7 +7,7 @@
 <div class="features-grid top narrow grey">
     <div class="ui search">
         <div class="ui massive input icon">
-            <%= form_with(url: search_admin_results_path, local: true) do |f| %>
+            <%= form_with(url: search_admin_results_path, local: true, method: :get) do |f| %>
                 <div class="ui input icon">
                     <%= f.text_field :domain_name, placeholder: t('search_by_domain_name') %>
                 </div>

--- a/app/views/admin/results/search.html.erb
+++ b/app/views/admin/results/search.html.erb
@@ -7,7 +7,7 @@
 <div class="features-grid top narrow grey">
     <div class="ui search">
         <div class="ui massive input icon">
-            <%= form_with(url: search_admin_results_path, local: true) do |f| %>
+            <%= form_with(url: search_admin_results_path, local: true, method: :get) do |f| %>
                 <div class="ui input icon">
                     <%= f.text_field :domain_name, placeholder: t('search_by_domain_name') %>
                 </div>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -7,7 +7,7 @@
 <div class="features-grid top narrow grey">
     <div class="ui search">
         <div class="ui massive input icon">
-            <%= form_with(url: search_admin_users_path, local: true) do |f| %>
+            <%= form_with(url: search_admin_users_path, local: true, method: :get) do |f| %>
                 <div class="ui input icon">
                     <%= f.text_field :email, placeholder: t('search_by_email') %>
                 </div>

--- a/app/views/admin/users/search.html.erb
+++ b/app/views/admin/users/search.html.erb
@@ -7,7 +7,7 @@
 <div class="features-grid top narrow grey">
     <div class="ui search">
         <div class="ui massive input icon">
-            <%= form_with(url: search_admin_users_path, local: true) do |f| %>
+            <%= form_with(url: search_admin_users_path, local: true, method: :get) do |f| %>
                 <div class="ui input icon">
                     <%= f.text_field :email, placeholder: t('search_by_email') %>
                 </div>

--- a/app/views/auctions/index.html.erb
+++ b/app/views/auctions/index.html.erb
@@ -9,7 +9,7 @@
 <div class="features-grid top narrow grey">
     <div class="ui search">
         <div class="ui massive input icon">
-            <%= form_with(url: search_auctions_path, local: true) do |f| %>
+            <%= form_with(url: search_auctions_path, local: true, method: :get) do |f| %>
                 <div class="ui input icon">
                     <%= f.text_field :domain_name, placeholder: t('.search') %>
                 </div>

--- a/app/views/auctions/search.html.erb
+++ b/app/views/auctions/search.html.erb
@@ -9,7 +9,7 @@
 <div class="features-grid top narrow grey">
     <div class="ui search">
         <div class="ui massive input icon">
-            <%= form_with(url: search_auctions_path, local: true) do |f| %>
+            <%= form_with(url: search_auctions_path, local: true, method: :get) do |f| %>
                 <div class="ui input icon">
                     <%= f.text_field :domain_name, placeholder: t('search_by_domain_name') %>
                 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
 
   concern :searchable do
     collection do
-      post 'search'
+      get 'search'
     end
   end
 


### PR DESCRIPTION
Fixes #127. There is some garbage in the URL after submit (`search?utf8=✓&domain_name=foo&button=`), but I guess we should live with that.