### PR TITLE
Fix reCAPTCHA strings

### DIFF
--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -87,4 +87,5 @@ et:
 
   recaptcha:
     errors:
-      recaptcha_unreachable: "reCAPTCHA kontroll ebaõnnestus. Palun proovige uuesti!"
+      recaptcha_unreachable: "reCAPTCHA ebaõnnestus. Palun proovige uuesti!"
+      verification_failed: "reCAPTCHA kontroll ebaõnnestus. Palun proovige uuesti!"


### PR DESCRIPTION
@vohmar I missed one translation string for reCAPTCHA. This translates them both. No testing is required.