### PR TITLE
Return cleanly to invoice after interrupted payment

### DIFF
--- a/app/controllers/payment_orders_controller.rb
+++ b/app/controllers/payment_orders_controller.rb
@@ -34,8 +34,10 @@ class PaymentOrdersController < ApplicationController
         format.html { redirect_to invoice_path(@payment_order.invoice.uuid), notice: t(:updated) }
         format.json { redirect_to invoice_path(@payment_order.invoice.uuid), notice: t(:updated) }
       else
-        format.html { redirect_to invoice_path(@payment_order.invoice.uuid),
-                      notice: t('.not_successful') }
+        format.html do
+          redirect_to invoice_path(@payment_order.invoice.uuid),
+                      notice: t('.not_successful')
+        end
         format.json { render json: @payment_order.errors, status: :unprocessable_entity }
       end
     end

--- a/app/controllers/payment_orders_controller.rb
+++ b/app/controllers/payment_orders_controller.rb
@@ -34,7 +34,8 @@ class PaymentOrdersController < ApplicationController
         format.html { redirect_to invoice_path(@payment_order.invoice.uuid), notice: t(:updated) }
         format.json { redirect_to invoice_path(@payment_order.invoice.uuid), notice: t(:updated) }
       else
-        format.html { redirect_to invoice_path(@payment_order.invoice.uuid), notice: t(:error) }
+        format.html { redirect_to invoice_path(@payment_order.invoice.uuid),
+                      notice: t('.not_successful') }
         format.json { render json: @payment_order.errors, status: :unprocessable_entity }
       end
     end

--- a/app/models/payment_orders/every_pay.rb
+++ b/app/models/payment_orders/every_pay.rb
@@ -51,7 +51,7 @@ module PaymentOrders
 
     # Perform necessary checks and mark the invoice as paid
     def mark_invoice_as_paid
-      return unless valid_response? && settled_payment?
+      return unless settled_payment? && valid_response?
 
       paid!
       time = Time.strptime(response['timestamp'], '%s')

--- a/config/locales/payment_orders.en.yml
+++ b/config/locales/payment_orders.en.yml
@@ -3,3 +3,6 @@ en:
     show:
       you_are_being_redirected: "You are being redirected to the payment gateway"
       please_wait: "Please wait"
+
+    return:
+      not_successful: "The payment was not successful."

--- a/config/locales/payment_orders.et.yml
+++ b/config/locales/payment_orders.et.yml
@@ -5,4 +5,4 @@ et:
       please_wait: "Palun oota"
 
     return:
-      not_successful: "The payment was not successful."
+      not_successful: "Makse ebaõnnestus!"

--- a/config/locales/payment_orders.et.yml
+++ b/config/locales/payment_orders.et.yml
@@ -3,3 +3,6 @@ et:
     show:
       you_are_being_redirected: "Sind suunatakse maksma"
       please_wait: "Palun oota"
+
+    return:
+      not_successful: "The payment was not successful."

--- a/test/models/payment_orders/payment_order_every_pay_test.rb
+++ b/test/models/payment_orders/payment_order_every_pay_test.rb
@@ -36,8 +36,11 @@ class PaymentOrderEveryPayTest < ActiveSupport::TestCase
     @every_pay = PaymentOrders::EveryPay.new(status: :issued, invoice: @orphaned_invoice,
                                              user: @user, response: response)
 
-    @fake_every_pay = PaymentOrders::EveryPay.new(status: :issued, invoice: @payable_invoice,
-                                                  user: @user)
+    @fake_every_pay = PaymentOrders::EveryPay.new(status: :issued,
+                                                  invoice: @payable_invoice,
+                                                  user: @user,
+                                                  response: {"payment_state": "cancelled",
+                                                             "hmac_fields": ""})
   end
 
   def teardown


### PR DESCRIPTION
Fixes #154

@vohmar, steps to test:
1. Create a new EveryPay payment.
2. Click cancel on EveryPay page.

You should be redirected back to invoice page with error message.