### PR TITLE
Do not allow to create duplicate offers

### DIFF
--- a/app/controllers/offers_controller.rb
+++ b/app/controllers/offers_controller.rb
@@ -18,11 +18,18 @@ class OffersController < ApplicationController
 
   # POST /auctions/aa450f1a-45e2-4f22-b2c3-f5f46b5f906b/offers
   def create
+    auction = Auction.find_by!(uuid: params[:auction_uuid])
+    existing_offer = auction.offer_from_user(current_user.id)
+
     @offer = Offer.new(create_params)
     authorize! :manage, @offer
 
     respond_to do |format|
-      if create_predicate
+      if existing_offer
+        format.html do
+          redirect_to offer_path(existing_offer.uuid), notice: t('offers.already_exists')
+        end
+      elsif create_predicate
         format.html { redirect_to offer_path(@offer.uuid), notice: t('.created') }
         format.json { render :show, status: :created, location: @offer }
       else

--- a/config/locales/offers.et.yml
+++ b/config/locales/offers.et.yml
@@ -5,7 +5,7 @@ et:
     i_accept_terms_and_conditions: "Nõustun tingimustega"
     price_in_currency: "%{price} €"
     price_is_without_vat: "Pakkumus ei sisalda käibemaksu."
-    already_exists: "You already have an offer for this auction."
+    already_exists: "Oled sellele oksjonile pakkumuse juba esitanud."
     errors: "seda pakkumust ei saa salvestada"
     total: "Käibemaksuga kokku"
     must_be_active: "peab olema aktiivne"


### PR DESCRIPTION
Steps to reproduce unwanted behaviour:

1. Open new offer page twice for the same user in two browser windows/tabs.
2. Try to submit two offers.

The later one should redirect you to view of existing offer. This is not a fix for someone submitting offers exactly at the same time, that would be an unique index. We might need an ability to have multiple offers from the same user from different auction types.

FYI @teadur 