### PR TITLE
Make invoice items be created in default locale context

### DIFF
--- a/app/models/invoice_creator.rb
+++ b/app/models/invoice_creator.rb
@@ -44,7 +44,8 @@ class InvoiceCreator
                       cents: result_offer.cents,
                       name: I18n.t('invoice_items.name',
                                    domain_name: result_auction.domain_name,
-                                   auction_end: result_auction.ends_at.to_date)),
+                                   auction_end: result_auction.ends_at.to_date,
+                                   locale: I18n.default_locale)),
     ]
   end
 


### PR DESCRIPTION
As it was pointed out, sometimes they're in one and sometimes in another language.