### PR TITLE
Add locale handling to payment orders

### DIFF
--- a/app/models/payment_orders/estonian_bank_link.rb
+++ b/app/models/payment_orders/estonian_bank_link.rb
@@ -6,6 +6,9 @@ module PaymentOrders
     SUCCESSFUL_PAYMENT_SERVICE_NUMBER = '1111'.freeze
     CANCELLED_PAYMENT_SERVICE_NUMBER  = '1911'.freeze
 
+    LANGUAGE_CODE_ET = 'EST'.freeze
+    LANGUAGE_CODE_EN = 'ENG'.freeze
+
     NEW_MESSAGE_KEYS     = %w[VK_SERVICE VK_VERSION VK_SND_ID VK_STAMP VK_AMOUNT
                               VK_CURR VK_REF VK_MSG VK_RETURN VK_CANCEL
                               VK_DATETIME].freeze
@@ -72,7 +75,7 @@ module PaymentOrders
       hash['VK_DATETIME'] = Time.zone.now.strftime('%Y-%m-%dT%H:%M:%S%z')
       hash['VK_MAC']      = calc_mac(hash)
       hash['VK_ENCODING'] = 'UTF-8'
-      hash['VK_LANG']     = 'ENG'
+      hash['VK_LANG']     = language
       hash
     end
 
@@ -101,6 +104,14 @@ module PaymentOrders
     end
 
     private
+
+    def language
+      if user&.locale == 'et'
+        LANGUAGE_CODE_ET
+      else
+        LANGUAGE_CODE_EN
+      end
+    end
 
     def valid_successful_transaction?
       valid_success_notice? && valid_amount? && valid_currency?

--- a/app/models/payment_orders/every_pay.rb
+++ b/app/models/payment_orders/every_pay.rb
@@ -20,6 +20,9 @@ module PaymentOrders
 
     SUCCESSFUL_PAYMENT = %w[settled authorized].freeze
 
+    LANGUAGE_CODE_ET = 'et'.freeze
+    LANGUAGE_CODE_EN = 'en'.freeze
+
     # Base interface for creating payments.
     def form_fields
       base_json = base_params
@@ -73,6 +76,14 @@ module PaymentOrders
 
     private
 
+    def language
+      if user&.locale == LANGUAGE_CODE_ET
+        LANGUAGE_CODE_ET
+      else
+        LANGUAGE_CODE_EN
+      end
+    end
+
     def valid_hmac?
       hmac_fields = response['hmac_fields'].split(',')
       hmac_hash = {}
@@ -103,6 +114,7 @@ module PaymentOrders
         amount: invoice.total.format(symbol: nil, thousands_separator: false, decimal_mark: '.'),
         order_reference: SecureRandom.hex(15),
         transaction_type: 'charge',
+        locale: language,
         hmac_fields: '',
       }.with_indifferent_access
     end

--- a/test/models/payment_orders/payment_order_estonian_bank_link_test.rb
+++ b/test/models/payment_orders/payment_order_estonian_bank_link_test.rb
@@ -53,7 +53,7 @@ class PaymentOrderEstonianBankLinkTest < ActiveSupport::TestCase
       form_fields = @new_bank_link.form_fields
 
       expected_fields.each do |k, v|
-        assert_equal v, form_fields[k]
+        assert_equal(v, form_fields[k])
       end
     end
   end
@@ -63,6 +63,38 @@ class PaymentOrderEstonianBankLinkTest < ActiveSupport::TestCase
 
     I18n.stub(:t, 'Invoice no. 1') do
       test_form_fields
+    end
+  end
+
+  def test_user_locale_is_mapped_to_vk_lang
+    @new_bank_link.user = @user
+    @orphaned_invoice.cents = Money.from_amount(1234.56, Setting.auction_currency).cents
+    assert_equal Money.from_amount(1481.47, Setting.auction_currency), @orphaned_invoice.total
+    @user.update!(locale: :et)
+
+    expected_fields = {
+      'VK_SERVICE': '1012',
+      'VK_VERSION': '008',
+      'VK_SND_ID': 'testvpos',
+      'VK_STAMP': 1,
+      'VK_AMOUNT': '1481.47',
+      'VK_CURR': 'EUR',
+      'VK_REF': '',
+      'VK_MSG': 'Invoice no. 1',
+      'VK_RETURN': 'return.url',
+      'VK_CANCEL': 'return.url',
+      'VK_DATETIME': '2010-07-05T10:30:00+0000',
+      'VK_MAC': 'E+R5WbTfdziFVR2bcgsH/Mapdz5JRv8P2rKhgdoSUQbjmnQ/vssXF/ZEVjU5fUXy+FI6w6Y33bJK6GHRUPhjbsKPChCPCGofe4gGjmFYyA5ODtQEpD29tcNii6K5gLsytmRI0k6/igXTMZOErY0K9zgJbxAPENh//iocxAjCjHs=',
+      'VK_ENCODING': 'UTF-8',
+      'VK_LANG': 'EST'
+    }.with_indifferent_access
+
+    @orphaned_invoice.stub(:number, 1) do
+      form_fields = @new_bank_link.form_fields
+
+      expected_fields.each do |k, v|
+        assert_equal(v, form_fields[k])
+      end
     end
   end
 

--- a/test/models/payment_orders/payment_order_every_pay_test.rb
+++ b/test/models/payment_orders/payment_order_every_pay_test.rb
@@ -61,7 +61,29 @@ class PaymentOrderEveryPayTest < ActiveSupport::TestCase
       timestamp: '1522542600',
       amount: '1200.00',
       transaction_type: 'charge',
-      hmac_fields: 'account_id,amount,api_username,callback_url,customer_url,hmac_fields,nonce,order_reference,timestamp,transaction_type'
+      hmac_fields: 'account_id,amount,api_username,callback_url,customer_url,hmac_fields,locale,nonce,order_reference,timestamp,transaction_type',
+      locale: 'en'
+    }
+    form_fields = @every_pay.form_fields
+    expected_fields.each do |k, v|
+      assert_equal(v, form_fields[k])
+    end
+  end
+
+  def test_form_fields_with_estonian_locale
+    @every_pay.user = @user
+    @orphaned_invoice.cents = Money.from_amount(1234.56, Setting.auction_currency).cents
+    assert_equal Money.from_amount(1481.47, Setting.auction_currency), @orphaned_invoice.total
+    @user.update!(locale: :et)
+
+    expected_fields = {
+      api_username: 'api_user',
+      account_id: 'EUR3D1',
+      timestamp: '1522542600',
+      amount: '1481.47',
+      transaction_type: 'charge',
+      hmac_fields: 'account_id,amount,api_username,callback_url,customer_url,hmac_fields,locale,nonce,order_reference,timestamp,transaction_type',
+      locale: 'et'
     }
     form_fields = @every_pay.form_fields
     expected_fields.each do |k, v|


### PR DESCRIPTION
Fixes #238. Applicable also to EveryPay, please test both.

Does not use country module, since neither of the payment gateways says that they accept language code in specific format, instead they do say that they support a number of languages marked by their own internal codes. 