### PR TITLE
Fix omniauth CVE

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -16,7 +16,7 @@
                 <div id="tara-sign-in" class="login-block ui segment">
                     <h3><%= t('.sign_in_with_identity_document') %></h3>
                     <p><%= t('.identity_document_text')%></p>
-                    <%= link_to t(:sign_in), "/auth/tara", class: "ui button big primary" %>
+                    <%= link_to t(:sign_in), "/auth/tara", method: :post, class: "ui button big primary" %>
                 </div>
             </div>
 

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,6 +1,9 @@
 OpenIDConnect.logger = Rails.logger
-OmniAuth.config.logger = Rails.logger
 OpenIDConnect.debug!
+
+OmniAuth.config.logger = Rails.logger
+# Block GET requests to avoid exposing self to CVE-2015-9284
+OmniAuth.config.allowed_request_methods = [:post]
 
 signing_keys = AuctionCenter::Application.config.customization.dig('tara', 'keys').to_json
 issuer = AuctionCenter::Application.config.customization.dig('tara', 'issuer')


### PR DESCRIPTION
Protect against CVE-2015-9284

Use POST method to initialize Tara request. No further action should be required anymore.

Please ensure that Tara login and user creation continues to work after this.