### PR TITLE
Mark which payment gateway was used to pay for the auction

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -11,6 +11,7 @@ class Invoice < ApplicationRecord
   belongs_to :billing_profile, optional: false
   has_many :invoice_items, dependent: :destroy
   has_many :payment_orders, dependent: :destroy
+  belongs_to :paid_with_payment_order, class_name: 'PaymentOrder', optional: true
 
   validates :user_id, presence: true, on: :create
   validates :issue_date, presence: true

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -92,6 +92,18 @@ class Invoice < ApplicationRecord
     end
   end
 
+  def mark_as_paid_at_with_payment_order(time, payment_order)
+    ActiveRecord::Base.transaction do
+      self.paid_at = time
+      self.vat_rate = billing_profile.vat_rate
+      self.total_amount = total
+      self.paid_with_payment_order = payment_order
+
+      paid!
+      result.mark_as_payment_received(time)
+    end
+  end
+
   def overdue?
     due_date < Time.zone.today && issued?
   end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -81,6 +81,9 @@ class Invoice < ApplicationRecord
     "#{title.parameterize}.pdf"
   end
 
+  # mark_as_paid_at_with_payment_order(time, payment_order) is the preferred version to use
+  # in the application, but this is also used with administrator manually setting invoice as
+  # paid in the user interface.
   def mark_as_paid_at(time)
     ActiveRecord::Base.transaction do
       self.paid_at = time

--- a/app/models/payment_order.rb
+++ b/app/models/payment_order.rb
@@ -42,6 +42,10 @@ class PaymentOrder < ApplicationRecord
     end
   end
 
+  def channel
+    type.gsub('PaymentOrders::', '')
+  end
+
   def self.supported_methods
     enabled = []
 

--- a/app/models/payment_orders/estonian_bank_link.rb
+++ b/app/models/payment_orders/estonian_bank_link.rb
@@ -83,7 +83,7 @@ module PaymentOrders
       if valid_response? && valid_success_notice?
         time = Time.zone.parse(response['VK_T_DATETIME'])
         paid!
-        invoice.mark_as_paid_at(time)
+        invoice.mark_as_paid_at_with_payment_order(time, self)
       elsif valid_response? && valid_cancel_notice?
         cancelled!
         false

--- a/app/models/payment_orders/every_pay.rb
+++ b/app/models/payment_orders/every_pay.rb
@@ -58,7 +58,7 @@ module PaymentOrders
 
       paid!
       time = Time.strptime(response['timestamp'], '%s')
-      invoice.mark_as_paid_at(time)
+      invoice.mark_as_paid_at_with_payment_order(time, self)
     end
 
     # Check if response is there and if basic security methods are fullfilled.

--- a/app/views/admin/invoices/index.html.erb
+++ b/app/views/admin/invoices/index.html.erb
@@ -76,6 +76,7 @@
                         <% else %>
                             <td></td>
                             <td></td>
+                            <td></td>
                         <% end %>
                         <td></td>
                     </tr>

--- a/app/views/admin/invoices/index.html.erb
+++ b/app/views/admin/invoices/index.html.erb
@@ -53,6 +53,10 @@
                         <%= t('invoices.total_paid') %>
                         <%= order_buttons('invoices.total_paid') %>
                     </th>
+                    <th scope="col">
+                        <%= t('invoices.paid_through') %>
+                    </th>
+
                     <th scope="col"><%= clear_order_button %></th>
                 </tr>
             </thead>
@@ -68,6 +72,7 @@
                         <% if invoice.paid? %>
                             <td><%= number_to_percentage(invoice.vat_rate * 100, precision: 0) %></td>
                             <td><%= t('offers.price_in_currency', price: invoice.total_amount) %></td>
+                            <td><%= invoice.paid_with_payment_order&.channel %></td>
                         <% else %>
                             <td></td>
                             <td></td>

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -62,6 +62,13 @@
                         <div class="header"><%= t('invoices.due_date') %></div>
                         <%= @invoice.due_date %>
                     </div>
+
+		    <% if @invoice.paid_with_payment_order %>
+			<div class="item">
+                            <div class="header"><%= t('invoices.paid_through') %></div>
+                            <%= @invoice.paid_with_payment_order&.channel %>
+			</div>
+		    <% end %>
                 </div>
             </div>
 

--- a/config/locales/invoices.en.yml
+++ b/config/locales/invoices.en.yml
@@ -23,6 +23,7 @@ en:
     number: "Number"
     total_paid: "Total paid"
     vat_rate_on_payment: "VAT rate on payment date"
+    paid_through: "Paid through"
 
     outstanding: "Outstanding invoices"
     paid: "Paid invoices"

--- a/db/migrate/20190722100652_add_successful_payment_order_reference.rb
+++ b/db/migrate/20190722100652_add_successful_payment_order_reference.rb
@@ -1,0 +1,5 @@
+class AddSuccessfulPaymentOrderReference < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :invoices, :paid_with_payment_order
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1007,6 +1007,7 @@ CREATE TABLE public.invoices (
     total_amount numeric,
     updated_by character varying,
     notes character varying,
+    paid_with_payment_order_id bigint,
     CONSTRAINT invoices_cents_are_positive CHECK ((cents > 0)),
     CONSTRAINT issued_at_earlier_than_payment_at CHECK ((issue_date <= due_date)),
     CONSTRAINT paid_at_is_filled_when_status_is_paid CHECK ((NOT ((status = 'paid'::public.invoice_status) AND (paid_at IS NULL)))),
@@ -1924,6 +1925,13 @@ CREATE INDEX index_invoices_on_billing_profile_id ON public.invoices USING btree
 
 
 --
+-- Name: index_invoices_on_paid_with_payment_order_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_invoices_on_paid_with_payment_order_id ON public.invoices USING btree (paid_with_payment_order_id);
+
+
+--
 -- Name: index_invoices_on_result_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -2362,6 +2370,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190424070710'),
 ('20190517063450'),
 ('20190517073827'),
-('20190521071232');
+('20190521071232'),
+('20190722100652');
 
 

--- a/test/models/invoice_test.rb
+++ b/test/models/invoice_test.rb
@@ -134,6 +134,18 @@ class InvoiceTest < ActiveSupport::TestCase
     assert_equal(time, @payable_invoice.paid_at)
   end
 
+  def test_mark_as_paid_at_with_payment_order
+    time = Time.parse('2010-07-06 10:30 +0000')
+    payment_order = payment_orders(:issued)
+    @payable_invoice.mark_as_paid_at_with_payment_order(time, payment_order)
+
+    assert(@payable_invoice.paid?)
+    assert(@payable_invoice.result.payment_received?)
+    assert_equal(time.to_date + 14, @payable_invoice.result.registration_due_date)
+    assert_equal(time, @payable_invoice.paid_at)
+    assert_equal(payment_order, @payable_invoice.paid_with_payment_order)
+  end
+
   def test_mark_as_paid_populates_vat_rate_and_total_amount
     time = Time.parse('2010-07-06 10:30 +0000').in_time_zone
     @payable_invoice.mark_as_paid_at(time)

--- a/test/models/payment_orders/payment_order_estonian_bank_link_test.rb
+++ b/test/models/payment_orders/payment_order_estonian_bank_link_test.rb
@@ -56,6 +56,10 @@ class PaymentOrderEstonianBankLinkTest < ActiveSupport::TestCase
     end
   end
 
+  def test_channel
+    assert_equal('SEB', @new_bank_link.channel)
+  end
+
   def test_form_fields_with_estonian_locale
     I18n.locale = 'et'
 

--- a/test/models/payment_orders/payment_order_every_pay_test.rb
+++ b/test/models/payment_orders/payment_order_every_pay_test.rb
@@ -94,6 +94,10 @@ class PaymentOrderEveryPayTest < ActiveSupport::TestCase
     assert_equal(PaymentOrders::EveryPay::URL, @every_pay.form_url)
   end
 
+  def test_channel
+    assert_equal('EveryPay', @every_pay.channel)
+  end
+
   def test_mark_invoice_as_paid_works_when_response_is_valid
     @every_pay.mark_invoice_as_paid
 

--- a/test/system/admin/admin_invoices_test.rb
+++ b/test/system/admin/admin_invoices_test.rb
@@ -79,6 +79,18 @@ class AdminInvoicesTest < ApplicationSystemTestCase
     assert_not(page.has_link?('Mark as paid'))
   end
 
+  def test_admin_can_see_which_channel_was_used_to_pay_the_invoice
+    @invoice.update(status: Invoice.statuses[:paid], paid_at: Time.now,
+                    vat_rate: @invoice.billing_profile.vat_rate, total_amount: @invoice.total,
+                    paid_with_payment_order: payment_orders(:issued))
+
+    visit admin_invoices_path
+    assert(page.has_text?('EveryPay'))
+
+    visit admin_invoice_path(@invoice)
+    assert(page.has_text?('EveryPay'))
+  end
+
   def test_admin_cannot_open_edit_page_if_invoice_is_already_paid
     visit admin_invoice_path(@invoice)
 


### PR DESCRIPTION
Adds indication to admin UI which payment channel was used to pay an invoice. It is only applicable to new invoices. Fixes #240 

![capybara-201907231116329621676360](https://user-images.githubusercontent.com/2331765/61708236-0210ed80-ad55-11e9-9167-e9594859466b.png)
![capybara-201907231116335758734655](https://user-images.githubusercontent.com/2331765/61708315-32588c00-ad55-11e9-998a-e56b7b39fd8f.png)
