### PR TITLE
Add punycode support to wishlist

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ gem 'omniauth-tara', github: 'internetee/omniauth-tara'
 gem 'pdfkit'
 gem 'rails-i18n'
 gem 'recaptcha'
+gem 'simpleidn'
 gem 'wkhtmltopdf-binary'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,6 +228,8 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
+    simpleidn (0.1.1)
+      unf (~> 0.1.4)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -246,6 +248,9 @@ GEM
     turbolinks-source (5.2.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.6)
     validate_email (0.1.6)
       activemodel (>= 3.0)
       mail (>= 2.2.5)
@@ -305,6 +310,7 @@ DEPENDENCIES
   recaptcha
   selenium-webdriver
   simplecov
+  simpleidn
   turbolinks (~> 5)
   web-console (>= 3.3.0)
   webdrivers
@@ -312,4 +318,4 @@ DEPENDENCIES
   wkhtmltopdf-binary
 
 BUNDLED WITH
-   2.0.1
+   2.0.2

--- a/app/javascript/packs/wishlist_items.js
+++ b/app/javascript/packs/wishlist_items.js
@@ -1,3 +1,11 @@
+import * as punycode from 'punycode';
+
+function formHandler() {
+		const domainNameField = document
+				.getElementById('wishlist_item_domain_name');
+		domainNameField.value = punycode.toUnicode(domainNameField.value);
+}
+
 function createListItem(string, document) {
     const listItem = document.createElement('li');
     listItem.innerHTML = string;
@@ -31,4 +39,12 @@ document.addEventListener('ajax:beforeSend', (event) => {
     errorsBlock.classList.add('hidden');
     const duplicate = errorsList.cloneNode();
     errorsList.replaceWith(duplicate);
+});
+
+document.addEventListener('turbolinks:load', (event) => {
+    const form = document.getElementById('wishlist_item_form');
+    const button = document.getElementById('wishlist_item_form_commit');
+
+    form.addEventListener('change', formHandler);
+    button.addEventListener('click', formHandler);
 });

--- a/app/javascript/packs/wishlist_items.js
+++ b/app/javascript/packs/wishlist_items.js
@@ -1,9 +1,9 @@
 import * as punycode from 'punycode';
 
 function formHandler() {
-		const domainNameField = document
-				.getElementById('wishlist_item_domain_name');
-		domainNameField.value = punycode.toUnicode(domainNameField.value);
+    const domainNameField = document
+        .getElementById('wishlist_item_domain_name');
+    domainNameField.value = punycode.toUnicode(domainNameField.value);
 }
 
 function createListItem(string, document) {

--- a/app/views/wishlist_items/index.html.erb
+++ b/app/views/wishlist_items/index.html.erb
@@ -51,7 +51,7 @@
             </div>
 
             <%= form_with(model: @wishlist_item, url: wishlist_items_path,
-                          class: "ui form big") do |f| %>
+                          class: "ui form big", id: "wishlist_item_form") do |f| %>
                 <%= f.hidden_field :user_id, value: @wishlist_item.user_id %>
 
                 <div class="field">
@@ -60,7 +60,7 @@
                 </div>
 
                 <div class="buttons">
-                    <%= f.submit t(:submit), class: "ui button primary" %>
+                    <%= f.submit t(:submit), class: "ui button primary", id: "wishlist_item_form_commit" %>
                 </div>
             <% end %>
             <br>

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
       "less": "^3.0.0",
       "less-loader": "^5.0.0",
       "libphonenumber-js": "^1.5.1",
+      "punycode": "^2.1.1",
       "rails-ujs": "^5.2.1",
       "resolve-url-loader": "^3.0.0",
       "turbolinks": "^5.2.0",

--- a/test/models/wishlist_item_test.rb
+++ b/test/models/wishlist_item_test.rb
@@ -33,6 +33,13 @@ class WishlistItemTest < ActiveSupport::TestCase
     assert_equal(['has too many items'], item.errors[:wishlist])
   end
 
+  def test_domain_name_is_automatically_converted_to_unicode
+    item = WishlistItem.new(user: @user, domain_name: 'xn--un-bka.ee')
+    item.validate
+
+    assert_equal('õun.ee', item.domain_name)
+  end
+
   def test_user_must_exist
     item = WishlistItem.new(user: @user, domain_name: 'dupe.test')
     assert(item.valid?)

--- a/test/system/wishlist_items_test.rb
+++ b/test/system/wishlist_items_test.rb
@@ -30,6 +30,14 @@ class WishlistItemsTest < ApplicationSystemTestCase
     assert(page.has_css?('div.notice', text: 'Created successfully.'))
   end
 
+  def test_punycode_items_are_converted_to_unicode
+    fill_in('wishlist_item[domain_name]', with: 'xn--un-bka.ee')
+    click_link_or_button('Submit')
+
+    assert(page.has_css?('div.notice', text: 'Created successfully.'))
+    assert(page.has_text?('õun.ee'))
+  end
+
   def test_domain_name_must_be_a_valid_domain
     fill_in('wishlist_item[domain_name]', with: 'not a real domain')
     click_link_or_button('Submit')

--- a/test/system/wishlist_items_test.rb
+++ b/test/system/wishlist_items_test.rb
@@ -38,6 +38,16 @@ class WishlistItemsTest < ApplicationSystemTestCase
     assert(page.has_text?('õun.ee'))
   end
 
+  def test_user_cannot_create_wishlist_items_in_the_name_of_other_user
+    other_user = users(:second_place_participant)
+
+    fill_in('wishlist_item[domain_name]', with: 'new-item.test')
+    page.evaluate_script("document.getElementById('wishlist_item_user_id').value = '#{other_user.id}'")
+
+    click_link_or_button('Submit')
+    assert(page.has_css?('div.alert', text: 'You are not authorized to access this page'))
+  end
+
   def test_domain_name_must_be_a_valid_domain
     fill_in('wishlist_item[domain_name]', with: 'not a real domain')
     click_link_or_button('Submit')

--- a/yarn.lock
+++ b/yarn.lock
@@ -4895,9 +4895,9 @@ node-gyp@^3.8.0:
     which "1"
 
 node-libs-browser@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/node-libs-browser/-/node-libs-browser-2.2.0.tgz#c72f60d9d46de08a940dedbb25f3ffa2f9bbaa77"
-  integrity sha512-5MQunG/oyOaBdttrL40dA7bUfPORLRWMUJLQtMg7nluxUvk5XwnLdL9twQHFAjRx/y7mIMkLKT9++qPbbk6BZA==
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/node-libs-browser/-/node-libs-browser-2.2.1.tgz#b64f513d18338625f90346d27b0d235e631f6425"
+  integrity sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==
   dependencies:
     assert "^1.1.1"
     browserify-zlib "^0.2.0"
@@ -4909,7 +4909,7 @@ node-libs-browser@^2.0.0:
     events "^3.0.0"
     https-browserify "^1.0.0"
     os-browserify "^0.3.0"
-    path-browserify "0.0.0"
+    path-browserify "0.0.1"
     process "^0.11.10"
     punycode "^1.2.4"
     querystring-es3 "^0.2.0"
@@ -4921,7 +4921,7 @@ node-libs-browser@^2.0.0:
     tty-browserify "0.0.0"
     url "^0.11.0"
     util "^0.11.0"
-    vm-browserify "0.0.4"
+    vm-browserify "^1.0.1"
 
 node-pre-gyp@^0.12.0:
   version "0.12.0"
@@ -5375,10 +5375,10 @@ pascalcase@^0.1.1:
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
 
-path-browserify@0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.0.tgz#a0b870729aae214005b7d5032ec2cbbb0fb4451a"
-  integrity sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=
+path-browserify@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.1.tgz#e6c4ddd7ed3aa27c68a20cc4e50e1a4ee83bbc4a"
+  integrity sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==
 
 path-complete-extname@^1.0.0:
   version "1.0.0"
@@ -6267,7 +6267,7 @@ punycode@^1.2.4, punycode@^1.4.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
   integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
 
-punycode@^2.1.0:
+punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
@@ -7793,12 +7793,10 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-vm-browserify@0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-0.0.4.tgz#5d7ea45bbef9e4a6ff65f95438e0a87c357d5a73"
-  integrity sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=
-  dependencies:
-    indexof "0.0.1"
+vm-browserify@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.0.tgz#bd76d6a23323e2ca8ffa12028dc04559c75f9019"
+  integrity sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw==
 
 void-elements@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
Fixes #270. Does not affect existing records, but any new wishlist item created past delivery of this feature is silently converted to unicode. Works on both javascript as well as backend level.