### PR TITLE
Update invoices.et.yml

### DIFF
--- a/config/locales/invoices.et.yml
+++ b/config/locales/invoices.et.yml
@@ -21,6 +21,9 @@ et:
     title: "arve nr %{number}"
     download: "laadi alla"
     number: "number"
+    vat_rate_on_payment: "käibemaksu protsent"
+    total_paid: "kokku makstud"
+    paid_through: "makseviis"
 
     outstanding: "tasumata arved"
     paid: "tasutud arved"


### PR DESCRIPTION
added missing translations for new column headers in invoices table at auction admin interface