### PR TITLE
Fix test

### DIFF
--- a/test/system/admin/admin_orderable_test.rb
+++ b/test/system/admin/admin_orderable_test.rb
@@ -20,7 +20,7 @@ class AdminOrderableTest < ApplicationSystemTestCase
   def test_auctions_are_orderable
     visit admin_auctions_path
 
-    click_link(id: 'admin_auction_decorators.number_of_offers_desc_button')
+    click_link(id: 'admin_auction_decorators.domain_name_desc_button')
     assert_appears_before('with-offers.test', 'expired.test')
   end
 


### PR DESCRIPTION
For some unknown reason, `click_link(id: 'admin_auction_decorator.number_of_offers_desc_button')` occasionally leads to test failure. Setting `wait` has no effect.

Does not affect production code.