### PR TITLE
Auctions: Make domain table stackable for mobile users

### DIFF
--- a/app/javascript/src/global/_common.scss
+++ b/app/javascript/src/global/_common.scss
@@ -158,4 +158,22 @@ strong {
     @include max-screen(991px) {
         margin: 40px 0;
     }
+
+    .auctions-table-mobile-infotainment {
+        @media only screen and (min-width: 768px) {
+            display: none;
+        }
+    }
+
+    #auctions-table > thead > tr {
+        th.auctions-table-cell-name-no-mobile {
+            @media only screen and (max-width: 767px) {
+                display: none !important;
+            }
+        }   
+    }
 }
+
+.ui.table.stackable thead {
+    background: #212224;
+  }

--- a/app/javascript/src/semantic-ui/definitions/collections/grid.less
+++ b/app/javascript/src/semantic-ui/definitions/collections/grid.less
@@ -1821,9 +1821,6 @@
   .ui.grid.grid.grid > .row > [class*="widescreen only"].column:not(.mobile) {
     display: none !important;
   }
-  .auction[class*="mobile only"]:not(.auction[class*="tablet computer large screen widescreen"]) {
-    display: none !important;
-  }
 }
 /* Tablet Only Hide */
 @media only screen and (min-width: @tabletBreakpoint) and (max-width: @largestTabletScreen) {
@@ -1831,7 +1828,6 @@
   .ui.grid.grid.grid > [class*="mobile only"].row:not(.tablet),
   .ui.grid.grid.grid > [class*="mobile only"].column:not(.tablet),
   .ui.grid.grid.grid > .row > [class*="mobile only"].column:not(.tablet) {
-    
     display: none !important;
   }
   .ui[class*="computer only"].grid.grid.grid:not(.tablet),
@@ -1920,21 +1916,5 @@
   }
 }
 
-@media only screen and (max-width: @largestMobileScreen) {
-  [class*="mobile hidden"],
-  [class*="tablet only"]:not(.mobile),
-  [class*="computer only"]:not(.mobile),
-  [class*="large monitor only"]:not(.mobile),
-  [class*="widescreen monitor only"]:not(.mobile),
-  [class*="or lower hidden"] {
-    display: none !important;
-  }
-}
-
-  @media only screen and (min-width: @tabletBreakpoint) {
-    [class*="mobile show"] {
-      display: none;
-    }
-  }
 
 .loadUIOverrides();

--- a/app/javascript/src/semantic-ui/definitions/collections/grid.less
+++ b/app/javascript/src/semantic-ui/definitions/collections/grid.less
@@ -1821,6 +1821,9 @@
   .ui.grid.grid.grid > .row > [class*="widescreen only"].column:not(.mobile) {
     display: none !important;
   }
+  .auction[class*="mobile only"]:not(.auction[class*="tablet computer large screen widescreen"]) {
+    display: none !important;
+  }
 }
 /* Tablet Only Hide */
 @media only screen and (min-width: @tabletBreakpoint) and (max-width: @largestTabletScreen) {
@@ -1828,6 +1831,7 @@
   .ui.grid.grid.grid > [class*="mobile only"].row:not(.tablet),
   .ui.grid.grid.grid > [class*="mobile only"].column:not(.tablet),
   .ui.grid.grid.grid > .row > [class*="mobile only"].column:not(.tablet) {
+    
     display: none !important;
   }
   .ui[class*="computer only"].grid.grid.grid:not(.tablet),
@@ -1927,10 +1931,10 @@
   }
 }
 
-.mobile-show {
   @media only screen and (min-width: @tabletBreakpoint) {
-      display: none !important;
+    [class*="mobile show"] {
+      display: none;
+    }
   }
-}
 
 .loadUIOverrides();

--- a/app/javascript/src/semantic-ui/definitions/collections/grid.less
+++ b/app/javascript/src/semantic-ui/definitions/collections/grid.less
@@ -1916,5 +1916,21 @@
   }
 }
 
+@media only screen and (max-width: @largestMobileScreen) {
+  [class*="mobile hidden"],
+  [class*="tablet only"]:not(.mobile),
+  [class*="computer only"]:not(.mobile),
+  [class*="large monitor only"]:not(.mobile),
+  [class*="widescreen monitor only"]:not(.mobile),
+  [class*="or lower hidden"] {
+    display: none !important;
+  }
+}
+
+.mobile-show {
+  @media only screen and (min-width: @tabletBreakpoint) {
+      display: none !important;
+  }
+}
 
 .loadUIOverrides();

--- a/app/javascript/src/semantic-ui/definitions/collections/table.less
+++ b/app/javascript/src/semantic-ui/definitions/collections/table.less
@@ -174,6 +174,7 @@
   }
   .ui.table:not(.unstackable) thead {
     display: @responsiveHeaderDisplay;
+    background: @headerBackground;
   }
   .ui.table:not(.unstackable) tfoot {
     display: @responsiveFooterDisplay;

--- a/app/javascript/src/semantic-ui/definitions/collections/table.less
+++ b/app/javascript/src/semantic-ui/definitions/collections/table.less
@@ -174,7 +174,6 @@
   }
   .ui.table:not(.unstackable) thead {
     display: @responsiveHeaderDisplay;
-    background: @headerBackground;
   }
   .ui.table:not(.unstackable) tfoot {
     display: @responsiveFooterDisplay;

--- a/app/views/auctions/index.html.erb
+++ b/app/views/auctions/index.html.erb
@@ -26,14 +26,14 @@
     <div class="margin-block narrow">
         <div class="grid one column">
             <div class="column">
-                <table class="ui table selectable mobile stackable fixed" id="auctions-table">
-                <thead class="mobile-show unstackable">
+                <table class="ui table selectable stackable fixed" id="auctions-table">
+                <thead class="mobile show">
                         <tr>
-                            <th scope="col">
+                            <th>
                                 <%= t('auctions.domain_name') %>
                                 <%= order_buttons('participant_auction_decorators.domain_name') %>
                             </th>
-                            <th scope="col">
+                            <th>
                                 <%= t('auctions.ends_at') %>
                                 <%= order_buttons('participant_auction_decorators.ends_at') %>
                             </th>
@@ -42,20 +42,20 @@
 
                     <thead class="mobile hidden">
                         <tr>
-                            <th scope="col">
+                            <th>
                                 <%= t('auctions.domain_name') %>
                                 <%= order_buttons('participant_auction_decorators.domain_name') %>
                             </th>
-                            <th scope="col">
+                            <th>
                                 <%= t('auctions.ends_at') %>
                                 <%= order_buttons('participant_auction_decorators.ends_at') %>
                             </th>
-                            <th scope="col">
+                            <th>
                                 <%= t('auctions.your_current_price') %>
                                 <%= order_buttons('participant_auction_decorators.users_offer_cents') %>
                             </th>
-                            <th scope="col"><%= t('auctions.offer_actions') %></th>
-                            <th scope="col"><%= clear_order_button %></th>
+                            <th><%= t('auctions.offer_actions') %></th>
+                            <th><%= clear_order_button %></th>
                         </tr>
                     </thead>
 
@@ -67,8 +67,8 @@
                                         <%= domain_name_with_embedded_colors(auction.domain_name) %>
                                     <% end %>
                                 </td>
-                                <td><span class="mobile-show"><%= t('auctions.ends_at') %> </span><%= I18n.l(auction.ends_at) %></td>
-                                <td><span class="mobile-show"><%= t('auctions.your_current_price') %>: </span><%= auction.users_price %></td>
+                                <td><span class="mobile show"><%= t('auctions.ends_at') %> </span><%= I18n.l(auction.ends_at) %></td>
+                                <td><span class="mobile show"><%= t('auctions.your_current_price') %>: </span><%= auction.users_price %></td>
                                 <td>
                                     <%- if auction.users_offer_uuid %>
                                         <%= link_to t('auctions.edit_your_offer'),

--- a/app/views/auctions/index.html.erb
+++ b/app/views/auctions/index.html.erb
@@ -27,7 +27,7 @@
         <div class="grid one column">
             <div class="column">
                 <table class="ui table selectable stackable fixed" id="auctions-table">
-                <thead class="mobile show">
+                    <thead>
                         <tr>
                             <th>
                                 <%= t('auctions.domain_name') %>
@@ -37,25 +37,12 @@
                                 <%= t('auctions.ends_at') %>
                                 <%= order_buttons('participant_auction_decorators.ends_at') %>
                             </th>
-                        </tr>
-                </thead>
-
-                    <thead class="mobile hidden">
-                        <tr>
-                            <th>
-                                <%= t('auctions.domain_name') %>
-                                <%= order_buttons('participant_auction_decorators.domain_name') %>
-                            </th>
-                            <th>
-                                <%= t('auctions.ends_at') %>
-                                <%= order_buttons('participant_auction_decorators.ends_at') %>
-                            </th>
-                            <th>
+                            <th class="auctions-table-cell-name-no-mobile">
                                 <%= t('auctions.your_current_price') %>
                                 <%= order_buttons('participant_auction_decorators.users_offer_cents') %>
                             </th>
-                            <th><%= t('auctions.offer_actions') %></th>
-                            <th><%= clear_order_button %></th>
+                            <th class="auctions-table-cell-name-no-mobile"><%= t('auctions.offer_actions') %></th>
+                            <th class="auctions-table-cell-name-no-mobile"><%= clear_order_button %></th>
                         </tr>
                     </thead>
 
@@ -67,8 +54,8 @@
                                         <%= domain_name_with_embedded_colors(auction.domain_name) %>
                                     <% end %>
                                 </td>
-                                <td><span class="mobile show"><%= t('auctions.ends_at') %> </span><%= I18n.l(auction.ends_at) %></td>
-                                <td><span class="mobile show"><%= t('auctions.your_current_price') %>: </span><%= auction.users_price %></td>
+                                <td><span class="auctions-table-mobile-infotainment"><%= t('auctions.ends_at') %> </span><%= I18n.l(auction.ends_at) %></td>
+                                <td><span class="auctions-table-mobile-infotainment"><%= t('auctions.your_current_price') %>: </span><%= auction.users_price %></td>
                                 <td>
                                     <%- if auction.users_offer_uuid %>
                                         <%= link_to t('auctions.edit_your_offer'),

--- a/app/views/auctions/index.html.erb
+++ b/app/views/auctions/index.html.erb
@@ -26,8 +26,21 @@
     <div class="margin-block narrow">
         <div class="grid one column">
             <div class="column">
-                <table class="ui table selectable unstackable fixed" id="auctions-table">
-                    <thead>
+                <table class="ui table selectable mobile stackable fixed" id="auctions-table">
+                <thead class="mobile-show unstackable">
+                        <tr>
+                            <th scope="col">
+                                <%= t('auctions.domain_name') %>
+                                <%= order_buttons('participant_auction_decorators.domain_name') %>
+                            </th>
+                            <th scope="col">
+                                <%= t('auctions.ends_at') %>
+                                <%= order_buttons('participant_auction_decorators.ends_at') %>
+                            </th>
+                        </tr>
+                </thead>
+
+                    <thead class="mobile hidden">
                         <tr>
                             <th scope="col">
                                 <%= t('auctions.domain_name') %>
@@ -54,8 +67,8 @@
                                         <%= domain_name_with_embedded_colors(auction.domain_name) %>
                                     <% end %>
                                 </td>
-                                <td><%= I18n.l(auction.ends_at) %></td>
-                                <td><%= auction.users_price %></td>
+                                <td><span class="mobile-show"><%= t('auctions.ends_at') %> </span><%= I18n.l(auction.ends_at) %></td>
+                                <td><span class="mobile-show"><%= t('auctions.your_current_price') %>: </span><%= auction.users_price %></td>
                                 <td>
                                     <%- if auction.users_offer_uuid %>
                                         <%= link_to t('auctions.edit_your_offer'),

--- a/app/views/auctions/search.html.erb
+++ b/app/views/auctions/search.html.erb
@@ -26,14 +26,14 @@
     <div class="margin-block narrow">
         <div class="grid one column">
             <div class="column">
-                <table class="ui table selectable mobile stackable fixed" id="auctions-table">
-                    <thead class="mobile-show">
+                <table class="ui table selectable stackable fixed" id="auctions-table">
+                    <thead class="mobile show">
                         <tr>
-                            <th scope="col">
+                            <th>
                                 <%= t('auctions.domain_name') %>
                                 <%= order_buttons('participant_auction_decorators.domain_name') %>
                             </th>
-                            <th scope="col">
+                            <th>
                                 <%= t('auctions.ends_at') %>
                                 <%= order_buttons('participant_auction_decorators.ends_at') %>
                             </th>
@@ -41,20 +41,20 @@
                     </thead>
                     <thead class="mobile hidden">
                         <tr>
-                            <th scope="col">
+                            <th>
                                 <%= t('auctions.domain_name') %>
                                 <%= order_buttons('participant_auction_decorators.domain_name') %>
                             </th>
-                            <th scope="col">
+                            <th>
                                 <%= t('auctions.ends_at') %>
                                 <%= order_buttons('participant_auction_decorators.ends_at') %>
                             </th>
-                            <th scope="col">
+                            <th>
                                 <%= t('auctions.your_current_price') %>
                                 <%= order_buttons('participant_auction_decorators.users_offer_cents') %>
                             </th>
-                            <th scope="col"><%= t('auctions.offer_actions') %></th>
-                            <th scope="col"><%= clear_order_button %></th>
+                            <th><%= t('auctions.offer_actions') %></th>
+                            <th><%= clear_order_button %></th>
                         </tr>
                     </thead>
 
@@ -64,8 +64,8 @@
                                 <td class="auction-domain-name monospace">
                                     <%= link_to auction.domain_name, auction_path(auction.uuid) %>
                                 </td>
-                                <td><span class="mobile-show"><%= t('auctions.ends_at') %> </span> <%= I18n.l(auction.ends_at) %></td>
-                                <td><span class="mobile-show"><%= t('auctions.your_current_price') %>:  </span><%= auction.users_price %></td>
+                                <td><span class="mobile show"><%= t('auctions.ends_at') %> </span> <%= I18n.l(auction.ends_at) %></td>
+                                <td><span class="mobile show"><%= t('auctions.your_current_price') %>:  </span><%= auction.users_price %></td>
                                 <td>
                                     <%- if auction.users_offer_uuid %>
                                         <%= link_to t('auctions.edit_your_offer'),

--- a/app/views/auctions/search.html.erb
+++ b/app/views/auctions/search.html.erb
@@ -26,8 +26,20 @@
     <div class="margin-block narrow">
         <div class="grid one column">
             <div class="column">
-                <table class="ui table selectable unstackable fixed" id="auctions-table">
-                    <thead>
+                <table class="ui table selectable mobile stackable fixed" id="auctions-table">
+                    <thead class="mobile-show">
+                        <tr>
+                            <th scope="col">
+                                <%= t('auctions.domain_name') %>
+                                <%= order_buttons('participant_auction_decorators.domain_name') %>
+                            </th>
+                            <th scope="col">
+                                <%= t('auctions.ends_at') %>
+                                <%= order_buttons('participant_auction_decorators.ends_at') %>
+                            </th>
+                        </tr>
+                    </thead>
+                    <thead class="mobile hidden">
                         <tr>
                             <th scope="col">
                                 <%= t('auctions.domain_name') %>
@@ -52,8 +64,8 @@
                                 <td class="auction-domain-name monospace">
                                     <%= link_to auction.domain_name, auction_path(auction.uuid) %>
                                 </td>
-                                <td><%= I18n.l(auction.ends_at) %></td>
-                                <td><%= auction.users_price %></td>
+                                <td><span class="mobile-show"><%= t('auctions.ends_at') %> </span> <%= I18n.l(auction.ends_at) %></td>
+                                <td><span class="mobile-show"><%= t('auctions.your_current_price') %>:  </span><%= auction.users_price %></td>
                                 <td>
                                     <%- if auction.users_offer_uuid %>
                                         <%= link_to t('auctions.edit_your_offer'),

--- a/app/views/auctions/search.html.erb
+++ b/app/views/auctions/search.html.erb
@@ -27,7 +27,7 @@
         <div class="grid one column">
             <div class="column">
                 <table class="ui table selectable stackable fixed" id="auctions-table">
-                    <thead class="mobile show">
+                    <thead>
                         <tr>
                             <th>
                                 <%= t('auctions.domain_name') %>
@@ -37,24 +37,12 @@
                                 <%= t('auctions.ends_at') %>
                                 <%= order_buttons('participant_auction_decorators.ends_at') %>
                             </th>
-                        </tr>
-                    </thead>
-                    <thead class="mobile hidden">
-                        <tr>
-                            <th>
-                                <%= t('auctions.domain_name') %>
-                                <%= order_buttons('participant_auction_decorators.domain_name') %>
-                            </th>
-                            <th>
-                                <%= t('auctions.ends_at') %>
-                                <%= order_buttons('participant_auction_decorators.ends_at') %>
-                            </th>
-                            <th>
+                            <th class="auctions-table-cell-name-no-mobile">
                                 <%= t('auctions.your_current_price') %>
                                 <%= order_buttons('participant_auction_decorators.users_offer_cents') %>
                             </th>
-                            <th><%= t('auctions.offer_actions') %></th>
-                            <th><%= clear_order_button %></th>
+                            <th class="auctions-table-cell-name-no-mobile"><%= t('auctions.offer_actions') %></th>
+                            <th class="auctions-table-cell-name-no-mobile"><%= clear_order_button %></th>
                         </tr>
                     </thead>
 
@@ -62,15 +50,17 @@
                         <% @auctions.each do |auction| %>
                             <tr class="auctions-table-row">
                                 <td class="auction-domain-name monospace">
-                                    <%= link_to auction.domain_name, auction_path(auction.uuid) %>
+                                    <%= link_to auction_path(auction.uuid) do %>
+                                        <%= domain_name_with_embedded_colors(auction.domain_name) %>
+                                    <% end %>
                                 </td>
-                                <td><span class="mobile show"><%= t('auctions.ends_at') %> </span> <%= I18n.l(auction.ends_at) %></td>
-                                <td><span class="mobile show"><%= t('auctions.your_current_price') %>:  </span><%= auction.users_price %></td>
+                                <td><span class="auctions-table-mobile-infotainment"><%= t('auctions.ends_at') %> </span><%= I18n.l(auction.ends_at) %></td>
+                                <td><span class="auctions-table-mobile-infotainment"><%= t('auctions.your_current_price') %>: </span><%= auction.users_price %></td>
                                 <td>
                                     <%- if auction.users_offer_uuid %>
                                         <%= link_to t('auctions.edit_your_offer'),
                                          edit_offer_path(auction.users_offer_uuid) %>
-                                    <% elsif auction.in_progress? %>
+                                    <% else %>
                                         <%= link_to t('auctions.submit_offer'),
                                          new_auction_offer_path(auction_uuid: auction.uuid) %>
                                     <% end %>


### PR DESCRIPTION
Makes the domain table stackable for mobile users on `/auctions` and `/auctions/search`. 

![image](https://user-images.githubusercontent.com/9388771/66393869-546cbc80-e9dc-11e9-8576-70ff54a6152a.png)

Closes #354. 

