### PR TITLE
Better test coverage for Estonia personal ID codes

### DIFF
--- a/lib/identity_code/estonia.rb
+++ b/lib/identity_code/estonia.rb
@@ -37,7 +37,7 @@ class IdentityCode
 
       if checknum == 10
         scales = [3, 4, 5, 6, 7, 8, 9, 1, 2, 3]
-        checknum  = combine_scale_with_number(scales, identity_code)
+        checknum = combine_scale_with_number(scales, identity_code)
 
         checknum == 10 ? 0 : checknum
       else

--- a/lib/identity_code/estonia.rb
+++ b/lib/identity_code/estonia.rb
@@ -37,7 +37,7 @@ class IdentityCode
 
       if checknum == 10
         scales = [3, 4, 5, 6, 7, 8, 9, 1, 2, 3]
-        checknum = combine_scale_with_number(scales, identity_code)
+        checknum  = combine_scale_with_number(scales, identity_code)
 
         checknum == 10 ? 0 : checknum
       else

--- a/lib/identity_code/estonia.rb
+++ b/lib/identity_code/estonia.rb
@@ -4,6 +4,10 @@ class IdentityCode
       valid_length? && valid_century? && valid_birth_date? && valid_check_digit?
     end
 
+    def invalid?
+      !valid?
+    end
+
     private
 
     def valid_century?

--- a/test/lib/identity_code_test.rb
+++ b/test/lib/identity_code_test.rb
@@ -31,14 +31,29 @@ class IdentityCodeTest < ActiveSupport::TestCase
     assert(identity_code.valid?)
   end
 
-  def test_is_valid_for_every_century
+  def test_validates_estonian_id_codes_correctly
+
+    # Valid estonian ID code for person born in 19th century
     identity_code = IdentityCode.new('EE', "14501234213")
     assert(identity_code.valid?)
 
+    # Valid estonian ID code for person born in 20th century
     identity_code = IdentityCode.new('EE', "38701234218")
     assert(identity_code.valid?)
 
+    # Valid estonian ID code for person born in 21th century
     identity_code = IdentityCode.new('EE', "60901234211")
     assert(identity_code.valid?)
+
+    # Incorrect estonian ID codes
+    identity_code = IdentityCode.new('EE', "29511234213")
+    assert_not(identity_code.valid?)
+
+    identity_code = IdentityCode.new('EE', "52501233210")
+    assert_not(identity_code.valid?)
+
+    identity_code = IdentityCode.new('EE', "44501234213")
+    assert_not(identity_code.valid?)
+
   end
 end

--- a/test/lib/identity_code_test.rb
+++ b/test/lib/identity_code_test.rb
@@ -47,13 +47,13 @@ class IdentityCodeTest < ActiveSupport::TestCase
 
     # Incorrect estonian ID codes
     identity_code = IdentityCode.new('EE', "29511234213")
-    assert_not(identity_code.valid?)
+    assert(identity_code.invalid?)
 
     identity_code = IdentityCode.new('EE', "52501233210")
-    assert_not(identity_code.valid?)
+    assert(identity_code.invalid?)
 
     identity_code = IdentityCode.new('EE', "44501234213")
-    assert_not(identity_code.valid?)
+    assert(identity_code.invalid?)
 
   end
 end

--- a/test/lib/identity_code_test.rb
+++ b/test/lib/identity_code_test.rb
@@ -30,4 +30,15 @@ class IdentityCodeTest < ActiveSupport::TestCase
     identity_code = IdentityCode.new('EE', array_of_codes.sample)
     assert(identity_code.valid?)
   end
+
+  def test_is_valid_for_every_century
+    identity_code = IdentityCode.new('EE', "14501234213")
+    assert(identity_code.valid?)
+
+    identity_code = IdentityCode.new('EE', "38701234218")
+    assert(identity_code.valid?)
+
+    identity_code = IdentityCode.new('EE', "60901234211")
+    assert(identity_code.valid?)
+  end
 end


### PR DESCRIPTION
At the moment, some of PR tests are failing because coverage for Estonia personal ID codes is poor. Provides better test coverage.