### PR TITLE
Fixes response bug if registry integration disabled

### DIFF
--- a/app/models/application_health_check/registry.rb
+++ b/app/models/application_health_check/registry.rb
@@ -3,16 +3,18 @@ module ApplicationHealthCheck
     include Concerns::HealthChecker
 
     def check
-      report_failure 'Registry integration disabled' unless integration_enabled
-
-      simple_check_endpoint(url: ::Registry::Base::BASE_URL,
-                            no_url_message: 'No Registry url set',
-                            fail_message: 'Cannot connect to Registry API',
-                            success_message: 'Registry integration is up and running')
+      if integration_disabled
+        report_failure 'Registry integration disabled'
+      else
+        simple_check_endpoint(url: ::Registry::Base::BASE_URL,
+                              no_url_message: 'No Registry url set',
+                              fail_message: 'Cannot connect to Registry API',
+                              success_message: 'Registry integration is up and running')
+      end
     end
 
-    def integration_enabled
-      AuctionCenter::Application.config.customization.dig('registry_integration', 'enabled')
+    def integration_disabled
+      !AuctionCenter::Application.config.customization.dig('registry_integration', 'enabled')
     end
   end
 end


### PR DESCRIPTION
Fixes a bug found on #429 - if registry integration was disabled, check endpoint was throwing wrong error message.