### PR TITLE
Some fixes to user profile edit form UI

### DIFF
--- a/app/javascript/packs/stylesheets/users.scss
+++ b/app/javascript/packs/stylesheets/users.scss
@@ -6,3 +6,11 @@
     margin-top: 25px;
     margin-bottom: 25px;
 }
+
+.field_with_errors {
+  margin-bottom: 10px;
+}
+
+.field_with_errors .label-password {
+  font-size: 14px;
+}

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -65,7 +65,7 @@
                 <h3 class="p3"><%= t('users.password') %></h3>
             <% end %>
             <div class="field">
-                <%= f.label :password, t('users.password') %>
+                <%= f.label :password, t('users.password'), class: 'label-password' %>
                 <%= f.password_field :password, autocomplete: "new-password" %>
                 <% if user.persisted? %>
                     <br><em><%= t('.you_can_leave_blank') %></em><br>
@@ -76,7 +76,7 @@
                 <br />
             </div>
             <div class="field">
-                <%= f.label :password_confirmation, t('users.password_confirmation') %><br />
+                <%= f.label :password_confirmation, t('users.password_confirmation') %>
                 <%= f.password_field :password_confirmation, autocomplete: "off" %>
             </div>
         </div>

--- a/app/views/users/_tara_form.html.erb
+++ b/app/views/users/_tara_form.html.erb
@@ -47,6 +47,13 @@
                     <% end %>
                 </div>
             </div>
+            <h3 class="p3"><%= t('.daily_summary') %></h3>
+            <div class="field">
+                <div class="ui checkbox">
+                    <%= f.check_box :daily_summary %>
+                    <%= f.label :daily_summary %>
+                </div>
+            </div>
         </div>
 
         <div class="column sixteen wide">

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,6 +12,8 @@ module AuctionCenter
     config.load_defaults 6.0
     config.autoloader = :classic
 
+    config.active_model.i18n_customize_full_message = true
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/locales/users.en.yml
+++ b/config/locales/users.en.yml
@@ -61,6 +61,7 @@ en:
       you_can_leave_blank: "leave blank if you don't want to change it"
       we_need_your_password: "we need your current password to confirm your changes)"
       data_from_identity_document: "Data from identity document"
+      daily_summary: "Daily summary"
 
     update:
       incorrect_password: 'Incorrect current password'

--- a/config/locales/users.en.yml
+++ b/config/locales/users.en.yml
@@ -11,7 +11,7 @@ en:
     country_code: "Country code"
     identity_code: "Identity code"
     terms_and_conditions: "Terms and conditions"
-    must_accept_terms_and_conditions: "must be accepted"
+    must_accept_terms_and_conditions: "Terms and conditions must be accepted"
     terms_and_conditions_accepted_at: "Terms and conditions accepted at"
     password: "Password"
     password_confirmation: "Password confirmation"
@@ -76,3 +76,24 @@ en:
       deleted: "You have been logged out and your account has been deleted."
     toggle_subscription:
       subscription_status_toggled_flash: "Subscription status changed."
+
+  activerecord:
+    errors:
+      models:
+        user:
+          attributes:
+            terms_and_conditions:
+              format: "%{message}"
+
+    attributes:
+      user:
+        display_name: "Display name"
+        given_names: "Given names"
+        surname: "Surname"
+        country: "Country"
+        email: "Email"
+        mobile_phone: "Mobile phone"
+        terms_and_conditions: "Terms and conditions"
+        password: "Password"
+        password_confirmation: "Password confirmation"
+        identity_code: "Identity code"

--- a/config/locales/users.et.yml
+++ b/config/locales/users.et.yml
@@ -11,7 +11,7 @@ et:
     country_code: "Riigikood"
     identity_code: "Isikukood"
     terms_and_conditions: "Kasutaja tingimused"
-    must_accept_terms_and_conditions: "tuleb nõustuda"
+    must_accept_terms_and_conditions: "Kasutajatingimustega peab nõustuma"
     terms_and_conditions_accepted_at: "Tingimustega nõustunud"
     password: "Salasõna"
     password_confirmation: "Salasõna kinnitus"
@@ -71,6 +71,13 @@ et:
       subscription_status_toggled_flash: "Igapäevase oksjoninimekirja saatmise seaded muudetud"
 
   activerecord:
+    errors:
+      models:
+        user:
+          attributes:
+            terms_and_conditions:
+              format: "%{message}"
+
     attributes:
       user:
         display_name: "Kuva nimi"

--- a/config/locales/users.et.yml
+++ b/config/locales/users.et.yml
@@ -52,6 +52,9 @@ et:
       currently_pending_confirmation: "Currently pending confirmation for %{email}."
       daily_summary: "Igapäevane oksjoninimekiri"
 
+    tara_form:
+      daily_summary: "Igapäevane oksjoninimekiri"
+
     update:
       incorrect_password: 'Vale salasõna'
 
@@ -76,7 +79,7 @@ et:
         country: "Riik"
         email: "E-post"
         mobile_phone: "Mobiil"
-        terms_and_conditions: "kasutaja tingimused"
+        terms_and_conditions: "Kasutaja tingimused"
         password: "Salasõna"
         password_confirmation: "Salasõna kinnitus"
         identity_code: "Isikukood"

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -14,7 +14,7 @@ class UserTest < ActiveSupport::TestCase
     assert_equal(["can't be blank"], user.errors[:password])
     assert_equal(["can't be blank"], user.errors[:email])
     assert_equal(["can't be blank", 'is invalid'], user.errors[:mobile_phone])
-    assert_equal(['must be accepted'], user.errors[:terms_and_conditions])
+    assert_equal(['Terms and conditions must be accepted'], user.errors[:terms_and_conditions])
     assert_equal(["can't be blank"], user.errors[:given_names])
     assert_equal(["can't be blank"], user.errors[:surname])
 


### PR DESCRIPTION
Adds domainlist email checkbox to tara user profile form.
Removes unnecessary spacing in password confirmation field and fixes error message on terms and conditions accepted in user profile form.

Closes #465, #462 