### PR TITLE
Add value format to Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+30.12.2019
+* Registration form UI issues and translation fixes [#462](https://github.com/internetee/auction_center/issues/462)
+* Fixed missing auction list checkbox issue in user profile [#465](https://github.com/internetee/auction_center/issues/465)
+
 27.12.2019
 * Accounts with unpaid invoices cannot be deleted [#385](https://github.com/internetee/auction_center/issues/385)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+27.12.2019
+* Accounts with unpaid invoices cannot be deleted [#385](https://github.com/internetee/auction_center/issues/385)
+
 19.12.2019
 * Added public health check page [#449](https://github.com/internetee/auction_center/pull/449)
 * Bump rack from 2.0.7 to 2.0.8 [#463](https://github.com/internetee/auction_center/pull/463)

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -115,7 +115,7 @@ module Admin
     end
 
     def set_phone_confirmation_toggle
-      @phone_confirmation_toggle = Setting.require_phone_confirmation
+      @phone_confirmation_toggle = Setting.find_by(code: 'require_phone_confirmation').retrieve
     end
 
     def default_order_params

--- a/app/controllers/concerns/user_notices.rb
+++ b/app/controllers/concerns/user_notices.rb
@@ -1,0 +1,17 @@
+module Concerns
+  module UserNotices
+    extend ActiveSupport::Concern
+
+    def notification_for_delete(user)
+      if user.deletable?
+        t('.deleted')
+      else
+        t('.cannot_delete')
+      end
+    end
+
+    def notification_for_update(email_changed)
+      email_changed ? t('.email_changed') : t(:updated)
+    end
+  end
+end

--- a/app/javascript/packs/stylesheets/users.scss
+++ b/app/javascript/packs/stylesheets/users.scss
@@ -6,3 +6,11 @@
     margin-top: 25px;
     margin-bottom: 25px;
 }
+
+.field_with_errors {
+  margin-bottom: 10px;
+}
+
+.field_with_errors .label-password {
+  font-size: 14px;
+}

--- a/app/models/admin_auction_decorator.rb
+++ b/app/models/admin_auction_decorator.rb
@@ -25,7 +25,7 @@ class AdminAuctionDecorator
   end
 
   def highest_price
-    Money.new(auction.highest_offer_cents, Setting.auction_currency)
+    Money.new(auction.highest_offer_cents, Setting.find_by(code: 'auction_currency').retrieve)
   end
 
   delegate :number_of_offers, to: :auction

--- a/app/models/application_health_check/api.rb
+++ b/app/models/application_health_check/api.rb
@@ -2,7 +2,7 @@ module ApplicationHealthCheck
   class API < OkComputer::Check
     include Concerns::HealthChecker
     def check
-      simple_check_endpoint(url: Setting.check_api_url,
+      simple_check_endpoint(url: Setting.find_by(code: 'check_api_url').retrieve,
                             no_url_message: 'No API check url set',
                             fail_message: 'API is down',
                             success_message: 'API is up and OK')

--- a/app/models/application_health_check/sms.rb
+++ b/app/models/application_health_check/sms.rb
@@ -3,7 +3,7 @@ module ApplicationHealthCheck
     include Concerns::HealthChecker
 
     def check
-      simple_check_endpoint(url: Setting.check_sms_url,
+      simple_check_endpoint(url: Setting.find_by(code: 'check_sms_url').retrieve,
                             no_url_message: 'No SMS check url set',
                             fail_message: 'SMS API is down',
                             success_message: 'SMS API is OK')

--- a/app/models/application_health_check/tara.rb
+++ b/app/models/application_health_check/tara.rb
@@ -3,7 +3,7 @@ module ApplicationHealthCheck
     include Concerns::HealthChecker
 
     def check
-      simple_check_endpoint(url: Setting.check_tara_url,
+      simple_check_endpoint(url: Setting.find_by(code: 'check_tara_url').retrieve,
                             no_url_message: 'Tara check URL is not set',
                             fail_message: 'Tara API is down',
                             success_message: 'Tara API is OK and running')

--- a/app/models/automatic_ban.rb
+++ b/app/models/automatic_ban.rb
@@ -35,12 +35,12 @@ class AutomaticBan
 
   def assign_ban_length
     now = Time.zone.now.to_datetime
-
-    if unpaid_invoices < Setting.ban_number_of_strikes
+    setting = Setting.find_by(code: 'ban_number_of_strikes').retrieve
+    if unpaid_invoices < setting
       @ban.update!(domain_name: domain_name, valid_from: now,
                    valid_until: now >> SHORT_BAN_PERIOD_IN_MONTHS)
-    elsif unpaid_invoices >= Setting.ban_number_of_strikes
-      @ban.update!(valid_until: now >> Setting.ban_length)
+    elsif unpaid_invoices >= setting
+      @ban.update!(valid_until: now >> Setting.find_by(code: 'ban_length').retrieve)
     end
   end
 

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -25,11 +25,12 @@ class Invoice < ApplicationRecord
     where('due_date < ? AND status = ?', Time.zone.today, statuses[:issued])
   }
 
-  scope :pending_payment_reminder, lambda { |number_of_days = Setting.invoice_reminder_in_days|
-    where('due_date = ? AND status = ?',
-          Time.zone.today + number_of_days,
-          statuses[:issued])
-  }
+  scope :pending_payment_reminder,
+        lambda { |number_of_days = Setting.find_by(code: 'invoice_reminder_in_days').retrieve|
+          where('due_date = ? AND status = ?',
+                Time.zone.today + number_of_days,
+                statuses[:issued])
+        }
 
   def self.create_from_result(result_id)
     result = Result.find_by(id: result_id)
@@ -58,7 +59,7 @@ class Invoice < ApplicationRecord
   end
 
   def price
-    Money.new(cents, Setting.auction_currency)
+    Money.new(cents, Setting.find_by(code: 'auction_currency').retrieve)
   end
 
   def total

--- a/app/models/invoice_creator.rb
+++ b/app/models/invoice_creator.rb
@@ -51,7 +51,7 @@ class InvoiceCreator
 
   def set_issue_and_due_date
     invoice.issue_date = Time.zone.today
-    invoice.due_date = Time.zone.today + Setting.payment_term
+    invoice.due_date = Time.zone.today + Setting.find_by(code: 'payment_term').retrieve
   end
 
   def create_invoice

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -4,6 +4,6 @@ class InvoiceItem < ApplicationRecord
   validates :name, presence: true
 
   def price
-    Money.new(cents, Setting.auction_currency)
+    Money.new(cents, Setting.find_by(code: 'auction_currency').retrieve)
   end
 end

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -17,10 +17,10 @@ class Offer < ApplicationRecord
   end
 
   def must_be_higher_than_minimum_offer
-    minimum_offer = Setting.auction_minimum_offer
+    minimum_offer = Setting.find_by(code: 'auction_minimum_offer').retrieve
     return if minimum_offer <= cents.to_i
 
-    currency = Setting.auction_currency
+    currency = Setting.find_by(code: 'auction_currency').retrieve
     minimum_offer_as_money = Money.new(minimum_offer, currency)
 
     errors.add(:price, I18n.t('offers.must_be_higher_than', minimum: minimum_offer_as_money))
@@ -31,12 +31,12 @@ class Offer < ApplicationRecord
   end
 
   def price
-    Money.new(cents, Setting.auction_currency)
+    Money.new(cents, Setting.find_by(code: 'auction_currency').retrieve)
   end
 
   def price=(value)
     number = value.to_d
-    price = Money.from_amount(number, Setting.auction_currency)
+    price = Money.from_amount(number, Setting.find_by(code: 'auction_currency').retrieve)
     self.cents = price.cents
   end
 

--- a/app/models/participant_auction_decorator.rb
+++ b/app/models/participant_auction_decorator.rb
@@ -25,7 +25,7 @@ class ParticipantAuctionDecorator
   end
 
   def users_price
-    Money.new(auction.users_offer_cents, Setting.auction_currency)
+    Money.new(auction.users_offer_cents, Setting.find_by(code: 'auction_currency').retrieve)
   end
 
   delegate :users_offer_id, to: :auction

--- a/app/models/payment_orders/estonian_bank_link.rb
+++ b/app/models/payment_orders/estonian_bank_link.rb
@@ -67,7 +67,7 @@ module PaymentOrders
       hash['VK_STAMP']    = invoice.number
       hash['VK_AMOUNT'] = invoice.total.format(symbol: nil, thousands_separator: false,
                                                decimal_mark: '.')
-      hash['VK_CURR']     = Setting.auction_currency
+      hash['VK_CURR']     = Setting.find_by(code: 'auction_currency').retrieve
       hash['VK_REF']      = ''
       hash['VK_MSG']      = invoice.title
       hash['VK_RETURN']   = return_url
@@ -138,7 +138,7 @@ module PaymentOrders
     end
 
     def valid_currency?
-      Setting.auction_currency == response['VK_CURR']
+      Setting.find_by(code: 'auction_currency').retrieve == response['VK_CURR']
     end
 
     def verify_mac(data, mac)

--- a/app/models/registry/auction_creator.rb
+++ b/app/models/registry/auction_creator.rb
@@ -22,11 +22,11 @@ module Registry
     private
 
     def auction_duration_in_seconds
-      Setting.auction_duration * 60 * 60
+      Setting.find_by(code: 'auction_duration').retrieve * 60 * 60
     end
 
     def auction_starts_at
-      setting = Setting.auctions_start_at
+      setting = Setting.find_by(code: 'auctions_start_at').retrieve
       if setting
         (Date.current + Rational(24 + setting, 24)).in_time_zone
       else
@@ -35,12 +35,12 @@ module Registry
     end
 
     def auction_ends_at
-      setting = Setting.auction_duration
+      setting = Setting.find_by(code: 'auction_duration').retrieve
 
       if setting == :end_of_day
         (auction_starts_at.to_date + 1).in_time_zone - 1
       else
-        Time.at(auction_starts_at.to_i + Setting.auction_duration * 60 * 60).in_time_zone
+        Time.at(auction_starts_at.to_i + setting * 60 * 60).in_time_zone
       end
     end
 

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -30,7 +30,7 @@ class Result < ApplicationRecord
   scope :pending_registration_reminder, lambda {
     where(status: Result.statuses[:payment_received])
       .where('registration_due_date <= ?',
-             Time.zone.today + Setting.domain_registration_reminder_day)
+             Time.zone.today + Setting.find_by(code: 'domain_registration_reminder').retrieve)
       .where('registration_reminder_sent_at IS NULL')
   }
 
@@ -58,7 +58,7 @@ class Result < ApplicationRecord
   end
 
   def mark_as_payment_received(time)
-    date = time.to_date + Setting.registration_term
+    date = time.to_date + Setting.find_by(code: 'registration_term').retrieve
     update!(status: Result.statuses[:payment_received],
             registration_due_date: date)
   end

--- a/app/models/result_creator.rb
+++ b/app/models/result_creator.rb
@@ -70,7 +70,9 @@ class ResultCreator
   end
 
   def assign_registration_due_date
-    result.registration_due_date = Time.zone.today + Setting.registration_term
+    result.registration_due_date = Time.zone.today + Setting.find_by(
+      code: 'registration_term'
+    ).retrieve
   end
 
   def create_result

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -3,37 +3,59 @@ class Setting < ApplicationRecord
   validates :code, presence: true, uniqueness: true
   validates :description, presence: true
   validates :value, presence: true
+  validates :value_format, presence: true
+  validate :valid_value_format
 
-  def self.auction_currency
-    Setting.find_by(code: :auction_currency).value
+  VALUE_FORMATS = {
+    string: :string_format,
+    integer: :integer_format,
+    boolean: :boolean_format,
+    hash: :hash_format,
+    array: :array_format,
+  }.with_indifferent_access.freeze
+
+  def retrieve
+    method = VALUE_FORMATS[value_format]
+    send(method)
   end
 
-  def self.auction_minimum_offer
-    Setting.find_by(code: :auction_minimum_offer).value.to_i
+  def valid_value_format
+    formats = VALUE_FORMATS.with_indifferent_access
+    errors.add(:value_format, :invalid) unless formats.keys.any? value_format
   end
 
-  def self.terms_and_conditions_link
-    value = Setting.find_by(code: :terms_and_conditions_link).value
+  def string_format
+    return auction_duration_value if code == 'auction_duration'
+    return auctions_start_at_value if code == 'auctions_start_at'
+
+    value
+  end
+
+  def integer_format
+    value.to_i
+  end
+
+  def boolean_format
+    value == 'true'
+  end
+
+  def hash_format
+    if %w[terms_and_conditions_link violations_count_regulations_link].include? code
+      return localized_hash_value
+    end
+
+    JSON.parse(value)
+  end
+
+  def localized_hash_value
     JSON.parse(value)[I18n.locale.to_s]
   end
 
-  def self.default_country
-    Setting.find_by(code: :default_country).value
+  def array_format
+    JSON.parse(value).to_a
   end
 
-  def self.payment_term
-    Setting.find_by(code: :payment_term).value.to_i
-  end
-
-  def self.registration_term
-    Setting.find_by(code: :registration_term).value.to_i
-  end
-
-  def self.auction_duration
-    value = Setting.find_by(code: :auction_duration).value
-
-    Setting.find_by(code: :auction_duration).value.to_i
-
+  def auction_duration_value
     if value == 'end_of_day'
       :end_of_day
     else
@@ -41,69 +63,11 @@ class Setting < ApplicationRecord
     end
   end
 
-  def self.require_phone_confirmation
-    value = Setting.find_by(code: :require_phone_confirmation).value
-
-    if value == 'true'
-      true
-    elsif value == 'false'
-      false
-    end
-  end
-
-  def self.auctions_start_at
-    value = Setting.find_by(code: :auctions_start_at).value
-
+  def auctions_start_at_value
     if value == 'false'
       false
     else
       value.to_i
     end
-  end
-
-  def self.ban_length
-    Setting.find_by(code: :ban_length).value.to_i
-  end
-
-  def self.ban_number_of_strikes
-    Setting.find_by(code: :ban_number_of_strikes).value.to_i
-  end
-
-  def self.domain_registration_reminder_day
-    Setting.find_by(code: :domain_registration_reminder).value.to_i
-  end
-
-  def self.invoice_issuer
-    Setting.find_by(code: :invoice_issuer).value
-  end
-
-  def self.invoice_reminder_in_days
-    Setting.find_by(code: :invoice_reminder_in_days).value.to_i
-  end
-
-  def self.wishlist_size
-    Setting.find_by(code: :wishlist_size).value.to_i
-  end
-
-  def self.check_api_url
-    Setting.find_by(code: :check_api_url)&.value
-  end
-
-  def self.check_sms_url
-    Setting.find_by(code: :check_sms_url)&.value
-  end
-
-  def self.check_tara_url
-    Setting.find_by(code: :check_tara_url)&.value
-  end
-
-  def self.violations_count_regulations_link
-    hash = Setting.find_by(code: :violations_count_regulations_link)&.value
-    hash.present? ? JSON.parse(hash).with_indifferent_access[I18n.locale] : nil
-  end
-
-  def self.wishlist_supported_domain_extensions
-    extensions = Setting.find_by(code: :wishlist_supported_domain_extensions)
-    extensions.present? ? JSON.parse(extensions.value) : []
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -72,7 +72,7 @@ class User < ApplicationRecord
   end
 
   def requires_phone_number_confirmation?
-    if Setting.require_phone_confirmation
+    if Setting.find_by(code: 'require_phone_confirmation').retrieve
       return false if signed_in_with_identity_document?
       return false if phone_number_confirmed?
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -67,6 +67,10 @@ class User < ApplicationRecord
     roles.include?(role)
   end
 
+  def deletable?
+    invoices&.issued&.blank?
+  end
+
   def signed_in_with_identity_document?
     provider == TARA_PROVIDER && uid.present?
   end

--- a/app/models/wishlist_item.rb
+++ b/app/models/wishlist_item.rb
@@ -28,7 +28,7 @@ class WishlistItem < ApplicationRecord
   # A user can only have limited number to discourage people from putting the whole zone into
   # the wishlist.
   def must_fit_in_wishlist_size
-    return if number_of_items_for_user < Setting.wishlist_size
+    return if number_of_items_for_user < Setting.find_by(code: 'wishlist_size').retrieve
 
     errors.add(:wishlist, I18n.t('wishlist_items.too_many_items'))
   end
@@ -55,8 +55,12 @@ class WishlistItem < ApplicationRecord
 
   # Validate that FQDN has supported extension
   def valid_domain_extension
-    return if Setting.wishlist_supported_domain_extensions.empty?
-    return if Setting.wishlist_supported_domain_extensions.include?(domain_name.split('.', 2).last)
+    return if Setting.find_by(code: 'wishlist_supported_domain_extensions').retrieve.empty?
+    if Setting.find_by(code: 'wishlist_supported_domain_extensions').retrieve.include?(
+      domain_name.split('.', 2).last
+    )
+      return
+    end
 
     errors.add(:domain_name, :invalid) if errors[:domain_name].blank?
   end

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -50,7 +50,7 @@
                 <div class="ui list">
                     <div class="item">
                         <div class="header"><%= t('invoices.issuer') %></div>
-                        <%= Setting.invoice_issuer %>
+                        <%= Setting.find_by(code: 'invoice_issuer').retrieve %>
                     </div>
 
                     <div class="item">

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -33,7 +33,7 @@
                 <%= f.select :country_code,
                 options_for_select(
                     Countries.for_selection,
-                    user.country_code || Setting.default_country
+                    user.country_code || Setting.find_by(code: 'default_country').retrieve
                 ),
                 { readonly: user.signed_in_with_identity_document? },
                 class: "ui dropdown" %>
@@ -44,7 +44,7 @@
                     <%= f.check_box :accepts_terms_and_conditions, { value: user.accepts_terms_and_conditions }, "true", "false" %>
                     <%= f.label :accepts_terms_and_conditions do %>
                         <%= t('users.i_accept_terms_and_conditions_html',
-                              link: link_to(t('users.terms_and_conditions_link'), Setting.terms_and_conditions_link)) %>
+                              link: link_to(t('users.terms_and_conditions_link'), Setting.find_by(code: 'terms_and_conditions_link').retrieve)) %>
                     <% end %>
                 </div>
             </div>

--- a/app/views/auctions/_top_grid.html.erb
+++ b/app/views/auctions/_top_grid.html.erb
@@ -40,7 +40,7 @@
             <p><strong><%= t(".please_note") %></strong></p>
             <p><%= t(".footer_html",
                      terms_and_conditions_link: link_to(t(".terms_and_conditions_link"),
-                                                        Setting.terms_and_conditions_link),
+                                                        Setting.find_by(code: 'terms_and_conditions_link').retrieve),
                      faq_link: link_to(t(".faq_link"), faq_link)) %></p>
         </div>
     </div>

--- a/app/views/auth/tara/_form.html.erb
+++ b/app/views/auth/tara/_form.html.erb
@@ -14,7 +14,7 @@
             <div class="field">
                 <%= f.label :country, t('users.country_code') %>
                 <div class="ui disabled input">
-                    <%= f.text_field :country_code, value: user.country_code || Setting.default_country,
+                    <%= f.text_field :country_code, value: user.country_code || Setting.find_by(code: 'default_country').retrieve,
                                      readonly: true %>
                 </div>
             </div>
@@ -45,7 +45,7 @@
                     <%= f.check_box :accepts_terms_and_conditions, { value: false }, "true", "false" %>
                     <%= f.label :accepts_terms_and_conditions do %>
                         <%= t('users.i_accept_terms_and_conditions_html',
-                              link: link_to(t('users.terms_and_conditions_link'), Setting.terms_and_conditions_link)) %>
+                              link: link_to(t('users.terms_and_conditions_link'), Setting.find_by(code: 'terms_and_conditions_link').retrieve)) %>
                     <% end %>
                 </div>
             </div>

--- a/app/views/billing_profiles/_form.html.erb
+++ b/app/views/billing_profiles/_form.html.erb
@@ -22,7 +22,7 @@
                 <%= f.select :country_code,
                 options_for_select(
                     Countries.for_selection,
-                    billing_profile.country_code || Setting.default_country
+                    billing_profile.country_code || Setting.find_by(code: 'default_country').retrieve
                 ),
                 {},
                 class: "ui selectable searchable dropdown" %>

--- a/app/views/common/pdf.html.erb
+++ b/app/views/common/pdf.html.erb
@@ -192,7 +192,7 @@
                             <%= t('invoices.issuer') %>
                         </dt>
                         <dd>
-                            <%= Setting.invoice_issuer %>
+                            <%= Setting.find_by(code: 'invoice_issuer').retrieve %>
                         </dd>
                         <dt>
                             <%= t('invoices.number') %>
@@ -285,7 +285,7 @@
                 <hr/>
                 <div class="row">
                     <div class="col-md-6 left">
-                        <%= Setting.invoice_issuer %>
+                        <%= Setting.find_by(code: 'invoice_issuer').retrieve %>
                     </div>
                 </div>
             </div>

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -30,7 +30,7 @@
                 <div class="ui list">
                     <div class="item">
                         <div class="header"><%= t('invoices.issuer') %></div>
-                        <%= Setting.invoice_issuer %>
+                        <%= Setting.find_by(code: 'invoice_issuer').retrieve %>
                     </div>
 
                     <div class="item">

--- a/app/views/notification_mailer/daily_summary_email.html.erb
+++ b/app/views/notification_mailer/daily_summary_email.html.erb
@@ -16,7 +16,7 @@
                 <% @winning_offers.each do |offer| %>
                     <tr>
                         <td><%= offer['domain_name'] %></td>
-                        <td><%= Money.new(offer['cents'], Setting.auction_currency) %></td>
+                        <td><%= Money.new(offer['cents'], Setting.find_by(code: 'auction_currency').retrieve) %></td>
                         <td><%= link_to(t('result_name'), admin_result_url(offer['result_id'])) %>
                     </tr>
                 <% end %>

--- a/app/views/offers/_form.html.erb
+++ b/app/views/offers/_form.html.erb
@@ -12,8 +12,8 @@
                 <br>
                 <em>
                     <%= t('.minimum_offer',
-                          minimum: Money.new(Setting.auction_minimum_offer,
-                                             Setting.auction_currency)) %>
+                          minimum: Money.new(Setting.find_by(code: 'auction_minimum_offer').retrieve,
+                                             Setting.find_by(code: 'auction_currency').retrieve)) %>
                     <%= t('offers.price_is_without_vat') %>
                 </em>
                 <br>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -34,7 +34,7 @@
                 <%= f.select :country_code,
                 options_for_select(
                     Countries.for_selection,
-                    user.country_code || Setting.default_country
+                    user.country_code || Setting.find_by(code: 'default_country').retrieve
                 ),
                 { readonly: false },
                 class: "ui dropdown" %>
@@ -45,7 +45,7 @@
                     <%= f.check_box :accepts_terms_and_conditions, { value: user.accepts_terms_and_conditions }, "true", "false" %>
                     <%= f.label :accepts_terms_and_conditions do %>
                         <%= t('users.i_accept_terms_and_conditions_html',
-                              link: link_to(t('users.terms_and_conditions_link'), Setting.terms_and_conditions_link)) %>
+                              link: link_to(t('users.terms_and_conditions_link'), Setting.find_by(code: 'terms_and_conditions_link').retrieve)) %>
                     <% end %>
                 </div>
             </div>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -65,7 +65,7 @@
                 <h3 class="p3"><%= t('users.password') %></h3>
             <% end %>
             <div class="field">
-                <%= f.label :password, t('users.password') %>
+                <%= f.label :password, t('users.password'), class: 'label-password' %>
                 <%= f.password_field :password, autocomplete: "new-password" %>
                 <% if user.persisted? %>
                     <br><em><%= t('.you_can_leave_blank') %></em><br>
@@ -76,7 +76,7 @@
                 <br />
             </div>
             <div class="field">
-                <%= f.label :password_confirmation, t('users.password_confirmation') %><br />
+                <%= f.label :password_confirmation, t('users.password_confirmation') %>
                 <%= f.password_field :password_confirmation, autocomplete: "off" %>
             </div>
         </div>

--- a/app/views/users/_tara_form.html.erb
+++ b/app/views/users/_tara_form.html.erb
@@ -12,7 +12,7 @@
                 <%= f.label :country, t('users.country_code') %>
                 <div class="ui disabled input">
                     <%= f.text_field :country_code,
-                        value: user.country_code || Setting.default_country,
+                        value: user.country_code || Setting.find_by(code: 'default_country').retrieve,
                         readonly: true %>
                 </div>
             </div>
@@ -43,7 +43,7 @@
                     <%= f.check_box :accepts_terms_and_conditions, { value: user.accepts_terms_and_conditions }, "true", "false" %>
                     <%= f.label :accepts_terms_and_conditions do %>
                         <%= t('users.i_accept_terms_and_conditions_html',
-                              link: link_to(t('users.terms_and_conditions_link'), Setting.terms_and_conditions_link)) %>
+                              link: link_to(t('users.terms_and_conditions_link'), Setting.find_by(code: 'terms_and_conditions_link').retrieve)) %>
                     <% end %>
                 </div>
             </div>

--- a/app/views/users/_tara_form.html.erb
+++ b/app/views/users/_tara_form.html.erb
@@ -47,6 +47,13 @@
                     <% end %>
                 </div>
             </div>
+            <h3 class="p3"><%= t('.daily_summary') %></h3>
+            <div class="field">
+                <div class="ui checkbox">
+                    <%= f.check_box :daily_summary %>
+                    <%= f.label :daily_summary %>
+                </div>
+            </div>
         </div>
 
         <div class="column sixteen wide">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -50,7 +50,7 @@
 
                         <tr>
                             <td><strong><%= t('users.terms_and_conditions') %></strong></td>
-                            <td><%= link_to t('.review_terms_and_conditions'), Setting.terms_and_conditions_link %></td>
+                            <td><%= link_to t('.review_terms_and_conditions'), Setting.find_by(code: 'terms_and_conditions_link').retrieve %></td>
                         </tr>
                         <tr>
                             <td><strong><%= t('.daily_summary') %></strong></td>

--- a/app/views/wishlist_items/index.html.erb
+++ b/app/views/wishlist_items/index.html.erb
@@ -7,7 +7,7 @@
 <div class="features-grid top green">
     <div class="overview">
         <div class="u-container">
-            <span class="title"><%= t('.limit_html', limit: Setting.wishlist_size) %></span>
+            <span class="title"><%= t('.limit_html', limit: Setting.find_by(code: 'wishlist_size').retrieve) %></span>
         </div>
     </div>
     <div class="u-container">

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,6 +12,8 @@ module AuctionCenter
     config.load_defaults 6.0
     config.autoloader = :classic
 
+    config.active_model.i18n_customize_full_message = true
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/locales/users.en.yml
+++ b/config/locales/users.en.yml
@@ -11,7 +11,7 @@ en:
     country_code: "Country code"
     identity_code: "Identity code"
     terms_and_conditions: "Terms and conditions"
-    must_accept_terms_and_conditions: "must be accepted"
+    must_accept_terms_and_conditions: "Terms and conditions must be accepted"
     terms_and_conditions_accepted_at: "Terms and conditions accepted at"
     password: "Password"
     password_confirmation: "Password confirmation"
@@ -77,3 +77,24 @@ en:
       cannot_delete: "Your account cannot be deleted because you got unpaid invoices."
     toggle_subscription:
       subscription_status_toggled_flash: "Subscription status changed."
+
+  activerecord:
+    errors:
+      models:
+        user:
+          attributes:
+            terms_and_conditions:
+              format: "%{message}"
+
+    attributes:
+      user:
+        display_name: "Display name"
+        given_names: "Given names"
+        surname: "Surname"
+        country: "Country"
+        email: "Email"
+        mobile_phone: "Mobile phone"
+        terms_and_conditions: "Terms and conditions"
+        password: "Password"
+        password_confirmation: "Password confirmation"
+        identity_code: "Identity code"

--- a/config/locales/users.en.yml
+++ b/config/locales/users.en.yml
@@ -61,6 +61,7 @@ en:
       you_can_leave_blank: "leave blank if you don't want to change it"
       we_need_your_password: "we need your current password to confirm your changes)"
       data_from_identity_document: "Data from identity document"
+      daily_summary: "Daily summary"
 
     update:
       incorrect_password: 'Incorrect current password'

--- a/config/locales/users.en.yml
+++ b/config/locales/users.en.yml
@@ -73,5 +73,6 @@ en:
 
     destroy:
       deleted: "You have been logged out and your account has been deleted."
+      cannot_delete: "Your account cannot be deleted because you got unpaid invoices."
     toggle_subscription:
       subscription_status_toggled_flash: "Subscription status changed."

--- a/config/locales/users.et.yml
+++ b/config/locales/users.et.yml
@@ -63,6 +63,7 @@ et:
 
     destroy:
       deleted: "Oled välja logitud ja sinu konto on kustutatud."
+      cannot_delete: "Kontot ei ole võimalik tasumata arvete tõttu kustutada."
 
     toggle_subscription:
       subscription_status_toggled_flash: "Igapäevase oksjoninimekirja saatmise seaded muudetud"

--- a/config/locales/users.et.yml
+++ b/config/locales/users.et.yml
@@ -52,6 +52,9 @@ et:
       currently_pending_confirmation: "Currently pending confirmation for %{email}."
       daily_summary: "Igapäevane oksjoninimekiri"
 
+    tara_form:
+      daily_summary: "Igapäevane oksjoninimekiri"
+
     update:
       incorrect_password: 'Vale salasõna'
 
@@ -77,7 +80,7 @@ et:
         country: "Riik"
         email: "E-post"
         mobile_phone: "Mobiil"
-        terms_and_conditions: "kasutaja tingimused"
+        terms_and_conditions: "Kasutaja tingimused"
         password: "Salasõna"
         password_confirmation: "Salasõna kinnitus"
         identity_code: "Isikukood"

--- a/config/locales/users.et.yml
+++ b/config/locales/users.et.yml
@@ -11,7 +11,7 @@ et:
     country_code: "Riigikood"
     identity_code: "Isikukood"
     terms_and_conditions: "Kasutaja tingimused"
-    must_accept_terms_and_conditions: "tuleb nõustuda"
+    must_accept_terms_and_conditions: "Kasutajatingimustega peab nõustuma"
     terms_and_conditions_accepted_at: "Tingimustega nõustunud"
     password: "Salasõna"
     password_confirmation: "Salasõna kinnitus"
@@ -72,6 +72,13 @@ et:
       subscription_status_toggled_flash: "Igapäevase oksjoninimekirja saatmise seaded muudetud"
 
   activerecord:
+    errors:
+      models:
+        user:
+          attributes:
+            terms_and_conditions:
+              format: "%{message}"
+
     attributes:
       user:
         display_name: "Kuva nimi"

--- a/db/migrate/20190213115909_add_result_registration_date_column.rb
+++ b/db/migrate/20190213115909_add_result_registration_date_column.rb
@@ -1,7 +1,7 @@
 class AddResultRegistrationDateColumn < ActiveRecord::Migration[5.2]
   def change
     add_column :results, :registration_due_date, :date
-    Result.all.update(registration_due_date: Date.today + Setting.registration_term)
+    Result.all.update(registration_due_date: Date.today + Setting.find_by(code: 'registration_term').retrieve)
     change_column_null :results, :registration_due_date, false
   end
 end

--- a/db/migrate/20191220131845_add_value_format_to_setting.rb
+++ b/db/migrate/20191220131845_add_value_format_to_setting.rb
@@ -1,0 +1,5 @@
+class AddValueFormatToSetting < ActiveRecord::Migration[6.0]
+  def change
+    add_column :settings, :value_format, :string, null: false, default: "string"
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -21,7 +21,7 @@ currency_description = <<~TEXT.squish
   EUR, USD, CAD, AUD, GBP, PLN, SEK. Default is: EUR
 TEXT
 currency_setting = Setting.new(code: :auction_currency, value: 'EUR',
-                               description: currency_description)
+                               description: currency_description, value_format: 'string')
 currency_setting.save
 
 # Minimum offer for the auction
@@ -29,7 +29,8 @@ auction_minimum_offer = Setting.new(
   code: :auction_minimum_offer,
   value: '500',
   description:
-  'Minimum amount in cents that a user can offer for a domain. Default is: 500 (5.00 EUR)'
+  'Minimum amount in cents that a user can offer for a domain. Default is: 500 (5.00 EUR)',
+  value_format: 'integer'
 )
 auction_minimum_offer.save
 
@@ -42,7 +43,8 @@ terms_and_conditions_description = <<~TEXT.squish
 TEXT
 terms_and_conditions_setting = Setting.new(code: :terms_and_conditions_link,
                                            value: "{\"en\":\"https://example.com\", \"et\":\"https://example.et\"}",
-                                           description: terms_and_conditions_description)
+                                           description: terms_and_conditions_description,
+                                           value_format: 'hash')
 terms_and_conditions_setting.save
 
 # Default country
@@ -52,7 +54,8 @@ default_country_description = <<~TEXT.squish
 TEXT
 
 default_country_setting = Setting.new(code: :default_country, value: 'EE',
-                                      description: default_country_description)
+                                      description: default_country_description,
+                                      value_format: 'string')
 default_country_setting.save
 
 # Default payment term
@@ -63,7 +66,8 @@ payment_term_description = <<~TEXT.squish
 TEXT
 
 payment_term_setting = Setting.new(code: :payment_term, value: '7',
-                                   description: payment_term_description)
+                                   description: payment_term_description,
+                                   value_format: 'integer')
 
 payment_term_setting.save
 
@@ -74,7 +78,8 @@ registration_term_description = <<~TEXT.squish
 TEXT
 
 registration_term_setting = Setting.new(code: :registration_term, value: '14',
-                                        description: registration_term_description)
+                                        description: registration_term_description,
+                                        value_format: 'integer')
 
 registration_term_setting.save
 
@@ -85,7 +90,8 @@ auction_duration_description = <<~TEXT.squish
 TEXT
 
 auction_duration_setting = Setting.new(code: :auction_duration, value: '24',
-                                       description: auction_duration_description)
+                                       description: auction_duration_description,
+                                       value_format: 'string')
 
 auction_duration_setting.save
 
@@ -97,7 +103,8 @@ TEXT
 
 phone_confirmation_setting = Setting.new(code: :require_phone_confirmation,
                                          value: 'false',
-                                         description: phone_confirmation_description)
+                                         description: phone_confirmation_description,
+                                         value_format: 'boolean')
 
 phone_confirmation_setting.save
 
@@ -108,7 +115,8 @@ auctions_start_at_description = <<~TEXT.squish
 TEXT
 
 auctions_start_at_setting = Setting.new(code: :auctions_start_at, value: '0',
-                                        description: auctions_start_at_description)
+                                        description: auctions_start_at_description,
+                                        value_format: 'string')
 
 auctions_start_at_setting.save
 
@@ -118,7 +126,8 @@ ban_length_description = <<~TEXT.squish
 TEXT
 
 ban_length_setting = Setting.new(code: :ban_length, value: '100',
-                                 description: ban_length_description)
+                                 description: ban_length_description,
+                                 value_format: 'integer')
 
 ban_length_setting.save
 
@@ -128,7 +137,8 @@ ban_number_of_strikes_description = <<~TEXT.squish
 TEXT
 
 ban_number_of_strikes_setting = Setting.new(code: :ban_number_of_strikes, value: '3',
-                                            description: ban_number_of_strikes_description)
+                                            description: ban_number_of_strikes_description,
+                                            value_format: 'integer')
 
 ban_number_of_strikes_setting.save
 
@@ -144,7 +154,8 @@ TEXT
 
 violations_count_regulations_setting = Setting.new(code: :violations_count_regulations_link,
                                             value: "{\"en\":\"https://example.com#some_anchor\"}",
-                                            description: violations_count_regulations_description)
+                                            description: violations_count_regulations_description,
+                                            value_format: 'hash')
 
 violations_count_regulations_setting.save!
 
@@ -155,7 +166,8 @@ domain_registration_description = <<~TEXT.squish
 TEXT
 
 domain_registration_setting = Setting.new(code: :domain_registration_reminder, value: '5',
-                                          description: domain_registration_description)
+                                          description: domain_registration_description,
+                                          value_format: 'integer')
 
 domain_registration_setting.save
 
@@ -171,7 +183,8 @@ invoice_issuer_value = <<~TEXT.squish
     TEXT
 
 invoice_issuer_setting = Setting.new(code: :invoice_issuer, value: invoice_issuer_value,
-                                     description: invoice_issuer_description)
+                                     description: invoice_issuer_description,
+                                     value_format: 'string')
 
 invoice_issuer_setting.save
 
@@ -182,7 +195,8 @@ invoice_reminder_description = <<~TEXT.squish
 TEXT
 
 invoice_reminder_setting = Setting.new(code: :invoice_reminder_in_days, value: '1',
-                                       description: invoice_reminder_description)
+                                       description: invoice_reminder_description,
+                                       value_format: 'integer')
 
 invoice_reminder_setting.save
 
@@ -193,7 +207,8 @@ wishlist_size_description = <<~TEXT.squish
 TEXT
 
 wishlist_size_setting = Setting.new(code: :wishlist_size, value: '10',
-                                    description: wishlist_size_description)
+                                    description: wishlist_size_description,
+                                    value_format: 'integer')
 wishlist_size_setting.save
 
 # Wishlist allowed domain extensions
@@ -204,7 +219,8 @@ TEXT
 extensions = ['ee', 'pri.ee', 'com.ee', 'med.ee', 'fie.ee']
 
 domain_extensions = Setting.new(code: :wishlist_supported_domain_extensions, value: extensions,
-                                    description: domain_extensions_description)
+                                    description: domain_extensions_description,
+                                    value_format: 'array')
 domain_extensions.save
 
 check_api_url_description = <<~TEXT.squish,
@@ -216,7 +232,8 @@ check_api_url_value = 'http://localhost/auctions.json'
 
 check_api_url = Setting.new(code: :check_api_url,
                             value: check_api_url_value,
-                            description: check_api_url_description)
+                            description: check_api_url_description,
+                            value_format: 'string')
 
 check_api_url.save!
 
@@ -229,7 +246,8 @@ check_sms_url_value = 'https://status.messente.com/api/v1/components/1'
 
 check_sms_url = Setting.new(code: :check_sms_url,
                             value: check_sms_url_value,
-                            description: check_sms_url_description)
+                            description: check_sms_url_description,
+                            value_format: 'string')
 
 check_sms_url.save!
 
@@ -242,6 +260,7 @@ check_tara_url_value = 'https://tara-test.ria.ee/oidc/jwks'
 
 check_tara_url = Setting.new(code: :check_tara_url,
                             value: check_tara_url_value,
-                            description: check_tara_url_description)
+                            description: check_tara_url_description,
+                            value_format: 'string')
 
 check_tara_url.save!

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -417,7 +417,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: auctions; Type: TABLE; Schema: audit; Owner: -; Tablespace:
+-- Name: auctions; Type: TABLE; Schema: audit; Owner: -; Tablespace: 
 --
 
 CREATE TABLE audit.auctions (
@@ -451,7 +451,7 @@ ALTER SEQUENCE audit.auctions_id_seq OWNED BY audit.auctions.id;
 
 
 --
--- Name: bans; Type: TABLE; Schema: audit; Owner: -; Tablespace:
+-- Name: bans; Type: TABLE; Schema: audit; Owner: -; Tablespace: 
 --
 
 CREATE TABLE audit.bans (
@@ -485,7 +485,7 @@ ALTER SEQUENCE audit.bans_id_seq OWNED BY audit.bans.id;
 
 
 --
--- Name: billing_profiles; Type: TABLE; Schema: audit; Owner: -; Tablespace:
+-- Name: billing_profiles; Type: TABLE; Schema: audit; Owner: -; Tablespace: 
 --
 
 CREATE TABLE audit.billing_profiles (
@@ -519,7 +519,7 @@ ALTER SEQUENCE audit.billing_profiles_id_seq OWNED BY audit.billing_profiles.id;
 
 
 --
--- Name: invoice_items; Type: TABLE; Schema: audit; Owner: -; Tablespace:
+-- Name: invoice_items; Type: TABLE; Schema: audit; Owner: -; Tablespace: 
 --
 
 CREATE TABLE audit.invoice_items (
@@ -553,7 +553,7 @@ ALTER SEQUENCE audit.invoice_items_id_seq OWNED BY audit.invoice_items.id;
 
 
 --
--- Name: invoices; Type: TABLE; Schema: audit; Owner: -; Tablespace:
+-- Name: invoices; Type: TABLE; Schema: audit; Owner: -; Tablespace: 
 --
 
 CREATE TABLE audit.invoices (
@@ -587,7 +587,7 @@ ALTER SEQUENCE audit.invoices_id_seq OWNED BY audit.invoices.id;
 
 
 --
--- Name: offers; Type: TABLE; Schema: audit; Owner: -; Tablespace:
+-- Name: offers; Type: TABLE; Schema: audit; Owner: -; Tablespace: 
 --
 
 CREATE TABLE audit.offers (
@@ -621,7 +621,7 @@ ALTER SEQUENCE audit.offers_id_seq OWNED BY audit.offers.id;
 
 
 --
--- Name: payment_orders; Type: TABLE; Schema: audit; Owner: -; Tablespace:
+-- Name: payment_orders; Type: TABLE; Schema: audit; Owner: -; Tablespace: 
 --
 
 CREATE TABLE audit.payment_orders (
@@ -655,7 +655,7 @@ ALTER SEQUENCE audit.payment_orders_id_seq OWNED BY audit.payment_orders.id;
 
 
 --
--- Name: results; Type: TABLE; Schema: audit; Owner: -; Tablespace:
+-- Name: results; Type: TABLE; Schema: audit; Owner: -; Tablespace: 
 --
 
 CREATE TABLE audit.results (
@@ -689,7 +689,7 @@ ALTER SEQUENCE audit.results_id_seq OWNED BY audit.results.id;
 
 
 --
--- Name: settings; Type: TABLE; Schema: audit; Owner: -; Tablespace:
+-- Name: settings; Type: TABLE; Schema: audit; Owner: -; Tablespace: 
 --
 
 CREATE TABLE audit.settings (
@@ -723,7 +723,7 @@ ALTER SEQUENCE audit.settings_id_seq OWNED BY audit.settings.id;
 
 
 --
--- Name: users; Type: TABLE; Schema: audit; Owner: -; Tablespace:
+-- Name: users; Type: TABLE; Schema: audit; Owner: -; Tablespace: 
 --
 
 CREATE TABLE audit.users (
@@ -757,7 +757,7 @@ ALTER SEQUENCE audit.users_id_seq OWNED BY audit.users.id;
 
 
 --
--- Name: wishlist_items; Type: TABLE; Schema: audit; Owner: -; Tablespace:
+-- Name: wishlist_items; Type: TABLE; Schema: audit; Owner: -; Tablespace: 
 --
 
 CREATE TABLE audit.wishlist_items (
@@ -791,7 +791,7 @@ ALTER SEQUENCE audit.wishlist_items_id_seq OWNED BY audit.wishlist_items.id;
 
 
 --
--- Name: ar_internal_metadata; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: ar_internal_metadata; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE public.ar_internal_metadata (
@@ -803,7 +803,7 @@ CREATE TABLE public.ar_internal_metadata (
 
 
 --
--- Name: auctions; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: auctions; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE public.auctions (
@@ -840,7 +840,7 @@ ALTER SEQUENCE public.auctions_id_seq OWNED BY public.auctions.id;
 
 
 --
--- Name: bans; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: bans; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE public.bans (
@@ -875,7 +875,7 @@ ALTER SEQUENCE public.bans_id_seq OWNED BY public.bans.id;
 
 
 --
--- Name: billing_profiles; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: billing_profiles; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE public.billing_profiles (
@@ -915,7 +915,7 @@ ALTER SEQUENCE public.billing_profiles_id_seq OWNED BY public.billing_profiles.i
 
 
 --
--- Name: delayed_jobs; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: delayed_jobs; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE public.delayed_jobs (
@@ -954,7 +954,7 @@ ALTER SEQUENCE public.delayed_jobs_id_seq OWNED BY public.delayed_jobs.id;
 
 
 --
--- Name: invoice_items; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: invoice_items; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE public.invoice_items (
@@ -988,7 +988,7 @@ ALTER SEQUENCE public.invoice_items_id_seq OWNED BY public.invoice_items.id;
 
 
 --
--- Name: invoices; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: invoices; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE public.invoices (
@@ -1056,7 +1056,7 @@ ALTER SEQUENCE public.invoices_number_seq OWNED BY public.invoices.number;
 
 
 --
--- Name: offers; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: offers; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE public.offers (
@@ -1093,7 +1093,7 @@ ALTER SEQUENCE public.offers_id_seq OWNED BY public.offers.id;
 
 
 --
--- Name: payment_orders; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: payment_orders; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE public.payment_orders (
@@ -1129,7 +1129,7 @@ ALTER SEQUENCE public.payment_orders_id_seq OWNED BY public.payment_orders.id;
 
 
 --
--- Name: results; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: results; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE public.results (
@@ -1169,7 +1169,7 @@ ALTER SEQUENCE public.results_id_seq OWNED BY public.results.id;
 
 
 --
--- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE public.schema_migrations (
@@ -1178,7 +1178,7 @@ CREATE TABLE public.schema_migrations (
 
 
 --
--- Name: settings; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: settings; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE public.settings (
@@ -1188,7 +1188,8 @@ CREATE TABLE public.settings (
     value text NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    updated_by character varying
+    updated_by character varying,
+    value_format character varying DEFAULT 'string'::character varying NOT NULL
 );
 
 
@@ -1212,7 +1213,7 @@ ALTER SEQUENCE public.settings_id_seq OWNED BY public.settings.id;
 
 
 --
--- Name: statistics_report_invoices; Type: MATERIALIZED VIEW; Schema: public; Owner: -; Tablespace:
+-- Name: statistics_report_invoices; Type: MATERIALIZED VIEW; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE MATERIALIZED VIEW public.statistics_report_invoices AS
@@ -1224,7 +1225,7 @@ CREATE MATERIALIZED VIEW public.statistics_report_invoices AS
 
 
 --
--- Name: users; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: users; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE public.users (
@@ -1280,7 +1281,7 @@ ALTER SEQUENCE public.users_id_seq OWNED BY public.users.id;
 
 
 --
--- Name: wishlist_items; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: wishlist_items; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE public.wishlist_items (
@@ -1481,7 +1482,7 @@ ALTER TABLE ONLY public.wishlist_items ALTER COLUMN id SET DEFAULT nextval('publ
 
 
 --
--- Name: auctions_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: auctions_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY public.auctions
@@ -1489,7 +1490,7 @@ ALTER TABLE ONLY public.auctions
 
 
 --
--- Name: statistics_report_auctions; Type: MATERIALIZED VIEW; Schema: public; Owner: -; Tablespace:
+-- Name: statistics_report_auctions; Type: MATERIALIZED VIEW; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE MATERIALIZED VIEW public.statistics_report_auctions AS
@@ -1521,7 +1522,7 @@ CREATE MATERIALIZED VIEW public.statistics_report_auctions AS
 
 
 --
--- Name: results_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: results_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY public.results
@@ -1529,7 +1530,7 @@ ALTER TABLE ONLY public.results
 
 
 --
--- Name: statistics_report_results; Type: MATERIALIZED VIEW; Schema: public; Owner: -; Tablespace:
+-- Name: statistics_report_results; Type: MATERIALIZED VIEW; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE MATERIALIZED VIEW public.statistics_report_results AS
@@ -1545,7 +1546,7 @@ CREATE MATERIALIZED VIEW public.statistics_report_results AS
 
 
 --
--- Name: auctions_pkey; Type: CONSTRAINT; Schema: audit; Owner: -; Tablespace:
+-- Name: auctions_pkey; Type: CONSTRAINT; Schema: audit; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY audit.auctions
@@ -1553,7 +1554,7 @@ ALTER TABLE ONLY audit.auctions
 
 
 --
--- Name: bans_pkey; Type: CONSTRAINT; Schema: audit; Owner: -; Tablespace:
+-- Name: bans_pkey; Type: CONSTRAINT; Schema: audit; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY audit.bans
@@ -1561,7 +1562,7 @@ ALTER TABLE ONLY audit.bans
 
 
 --
--- Name: billing_profiles_pkey; Type: CONSTRAINT; Schema: audit; Owner: -; Tablespace:
+-- Name: billing_profiles_pkey; Type: CONSTRAINT; Schema: audit; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY audit.billing_profiles
@@ -1569,7 +1570,7 @@ ALTER TABLE ONLY audit.billing_profiles
 
 
 --
--- Name: invoice_items_pkey; Type: CONSTRAINT; Schema: audit; Owner: -; Tablespace:
+-- Name: invoice_items_pkey; Type: CONSTRAINT; Schema: audit; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY audit.invoice_items
@@ -1577,7 +1578,7 @@ ALTER TABLE ONLY audit.invoice_items
 
 
 --
--- Name: invoices_pkey; Type: CONSTRAINT; Schema: audit; Owner: -; Tablespace:
+-- Name: invoices_pkey; Type: CONSTRAINT; Schema: audit; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY audit.invoices
@@ -1585,7 +1586,7 @@ ALTER TABLE ONLY audit.invoices
 
 
 --
--- Name: offers_pkey; Type: CONSTRAINT; Schema: audit; Owner: -; Tablespace:
+-- Name: offers_pkey; Type: CONSTRAINT; Schema: audit; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY audit.offers
@@ -1593,7 +1594,7 @@ ALTER TABLE ONLY audit.offers
 
 
 --
--- Name: payment_orders_pkey; Type: CONSTRAINT; Schema: audit; Owner: -; Tablespace:
+-- Name: payment_orders_pkey; Type: CONSTRAINT; Schema: audit; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY audit.payment_orders
@@ -1601,7 +1602,7 @@ ALTER TABLE ONLY audit.payment_orders
 
 
 --
--- Name: results_pkey; Type: CONSTRAINT; Schema: audit; Owner: -; Tablespace:
+-- Name: results_pkey; Type: CONSTRAINT; Schema: audit; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY audit.results
@@ -1609,7 +1610,7 @@ ALTER TABLE ONLY audit.results
 
 
 --
--- Name: settings_pkey; Type: CONSTRAINT; Schema: audit; Owner: -; Tablespace:
+-- Name: settings_pkey; Type: CONSTRAINT; Schema: audit; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY audit.settings
@@ -1617,7 +1618,7 @@ ALTER TABLE ONLY audit.settings
 
 
 --
--- Name: users_pkey; Type: CONSTRAINT; Schema: audit; Owner: -; Tablespace:
+-- Name: users_pkey; Type: CONSTRAINT; Schema: audit; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY audit.users
@@ -1625,7 +1626,7 @@ ALTER TABLE ONLY audit.users
 
 
 --
--- Name: wishlist_items_pkey; Type: CONSTRAINT; Schema: audit; Owner: -; Tablespace:
+-- Name: wishlist_items_pkey; Type: CONSTRAINT; Schema: audit; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY audit.wishlist_items
@@ -1633,7 +1634,7 @@ ALTER TABLE ONLY audit.wishlist_items
 
 
 --
--- Name: ar_internal_metadata_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: ar_internal_metadata_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY public.ar_internal_metadata
@@ -1641,7 +1642,7 @@ ALTER TABLE ONLY public.ar_internal_metadata
 
 
 --
--- Name: bans_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: bans_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY public.bans
@@ -1649,7 +1650,7 @@ ALTER TABLE ONLY public.bans
 
 
 --
--- Name: billing_profiles_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: billing_profiles_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY public.billing_profiles
@@ -1657,7 +1658,7 @@ ALTER TABLE ONLY public.billing_profiles
 
 
 --
--- Name: delayed_jobs_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: delayed_jobs_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY public.delayed_jobs
@@ -1665,7 +1666,7 @@ ALTER TABLE ONLY public.delayed_jobs
 
 
 --
--- Name: invoice_items_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: invoice_items_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY public.invoice_items
@@ -1673,7 +1674,7 @@ ALTER TABLE ONLY public.invoice_items
 
 
 --
--- Name: invoices_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: invoices_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY public.invoices
@@ -1681,7 +1682,7 @@ ALTER TABLE ONLY public.invoices
 
 
 --
--- Name: offers_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: offers_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY public.offers
@@ -1689,7 +1690,7 @@ ALTER TABLE ONLY public.offers
 
 
 --
--- Name: payment_orders_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: payment_orders_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY public.payment_orders
@@ -1697,7 +1698,7 @@ ALTER TABLE ONLY public.payment_orders
 
 
 --
--- Name: schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY public.schema_migrations
@@ -1705,7 +1706,7 @@ ALTER TABLE ONLY public.schema_migrations
 
 
 --
--- Name: settings_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: settings_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY public.settings
@@ -1713,7 +1714,7 @@ ALTER TABLE ONLY public.settings
 
 
 --
--- Name: unique_domain_name_per_auction_duration; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: unique_domain_name_per_auction_duration; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY public.auctions
@@ -1721,7 +1722,7 @@ ALTER TABLE ONLY public.auctions
 
 
 --
--- Name: users_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: users_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY public.users
@@ -1729,7 +1730,7 @@ ALTER TABLE ONLY public.users
 
 
 --
--- Name: wishlist_items_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: wishlist_items_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY public.wishlist_items
@@ -1737,434 +1738,434 @@ ALTER TABLE ONLY public.wishlist_items
 
 
 --
--- Name: auctions_object_id_idx; Type: INDEX; Schema: audit; Owner: -; Tablespace:
+-- Name: auctions_object_id_idx; Type: INDEX; Schema: audit; Owner: -; Tablespace: 
 --
 
 CREATE INDEX auctions_object_id_idx ON audit.auctions USING btree (object_id);
 
 
 --
--- Name: auctions_recorded_at_idx; Type: INDEX; Schema: audit; Owner: -; Tablespace:
+-- Name: auctions_recorded_at_idx; Type: INDEX; Schema: audit; Owner: -; Tablespace: 
 --
 
 CREATE INDEX auctions_recorded_at_idx ON audit.auctions USING btree (recorded_at);
 
 
 --
--- Name: bans_object_id_idx; Type: INDEX; Schema: audit; Owner: -; Tablespace:
+-- Name: bans_object_id_idx; Type: INDEX; Schema: audit; Owner: -; Tablespace: 
 --
 
 CREATE INDEX bans_object_id_idx ON audit.bans USING btree (object_id);
 
 
 --
--- Name: bans_recorded_at_idx; Type: INDEX; Schema: audit; Owner: -; Tablespace:
+-- Name: bans_recorded_at_idx; Type: INDEX; Schema: audit; Owner: -; Tablespace: 
 --
 
 CREATE INDEX bans_recorded_at_idx ON audit.bans USING btree (recorded_at);
 
 
 --
--- Name: billing_profiles_object_id_idx; Type: INDEX; Schema: audit; Owner: -; Tablespace:
+-- Name: billing_profiles_object_id_idx; Type: INDEX; Schema: audit; Owner: -; Tablespace: 
 --
 
 CREATE INDEX billing_profiles_object_id_idx ON audit.billing_profiles USING btree (object_id);
 
 
 --
--- Name: billing_profiles_recorded_at_idx; Type: INDEX; Schema: audit; Owner: -; Tablespace:
+-- Name: billing_profiles_recorded_at_idx; Type: INDEX; Schema: audit; Owner: -; Tablespace: 
 --
 
 CREATE INDEX billing_profiles_recorded_at_idx ON audit.billing_profiles USING btree (recorded_at);
 
 
 --
--- Name: invoice_items_object_id_idx; Type: INDEX; Schema: audit; Owner: -; Tablespace:
+-- Name: invoice_items_object_id_idx; Type: INDEX; Schema: audit; Owner: -; Tablespace: 
 --
 
 CREATE INDEX invoice_items_object_id_idx ON audit.invoice_items USING btree (object_id);
 
 
 --
--- Name: invoice_items_recorded_at_idx; Type: INDEX; Schema: audit; Owner: -; Tablespace:
+-- Name: invoice_items_recorded_at_idx; Type: INDEX; Schema: audit; Owner: -; Tablespace: 
 --
 
 CREATE INDEX invoice_items_recorded_at_idx ON audit.invoice_items USING btree (recorded_at);
 
 
 --
--- Name: invoices_object_id_idx; Type: INDEX; Schema: audit; Owner: -; Tablespace:
+-- Name: invoices_object_id_idx; Type: INDEX; Schema: audit; Owner: -; Tablespace: 
 --
 
 CREATE INDEX invoices_object_id_idx ON audit.invoices USING btree (object_id);
 
 
 --
--- Name: invoices_recorded_at_idx; Type: INDEX; Schema: audit; Owner: -; Tablespace:
+-- Name: invoices_recorded_at_idx; Type: INDEX; Schema: audit; Owner: -; Tablespace: 
 --
 
 CREATE INDEX invoices_recorded_at_idx ON audit.invoices USING btree (recorded_at);
 
 
 --
--- Name: offers_object_id_idx; Type: INDEX; Schema: audit; Owner: -; Tablespace:
+-- Name: offers_object_id_idx; Type: INDEX; Schema: audit; Owner: -; Tablespace: 
 --
 
 CREATE INDEX offers_object_id_idx ON audit.offers USING btree (object_id);
 
 
 --
--- Name: offers_recorded_at_idx; Type: INDEX; Schema: audit; Owner: -; Tablespace:
+-- Name: offers_recorded_at_idx; Type: INDEX; Schema: audit; Owner: -; Tablespace: 
 --
 
 CREATE INDEX offers_recorded_at_idx ON audit.offers USING btree (recorded_at);
 
 
 --
--- Name: payment_orders_object_id_idx; Type: INDEX; Schema: audit; Owner: -; Tablespace:
+-- Name: payment_orders_object_id_idx; Type: INDEX; Schema: audit; Owner: -; Tablespace: 
 --
 
 CREATE INDEX payment_orders_object_id_idx ON audit.payment_orders USING btree (object_id);
 
 
 --
--- Name: payment_orders_recorded_at_idx; Type: INDEX; Schema: audit; Owner: -; Tablespace:
+-- Name: payment_orders_recorded_at_idx; Type: INDEX; Schema: audit; Owner: -; Tablespace: 
 --
 
 CREATE INDEX payment_orders_recorded_at_idx ON audit.payment_orders USING btree (recorded_at);
 
 
 --
--- Name: results_object_id_idx; Type: INDEX; Schema: audit; Owner: -; Tablespace:
+-- Name: results_object_id_idx; Type: INDEX; Schema: audit; Owner: -; Tablespace: 
 --
 
 CREATE INDEX results_object_id_idx ON audit.results USING btree (object_id);
 
 
 --
--- Name: results_recorded_at_idx; Type: INDEX; Schema: audit; Owner: -; Tablespace:
+-- Name: results_recorded_at_idx; Type: INDEX; Schema: audit; Owner: -; Tablespace: 
 --
 
 CREATE INDEX results_recorded_at_idx ON audit.results USING btree (recorded_at);
 
 
 --
--- Name: settings_object_id_idx; Type: INDEX; Schema: audit; Owner: -; Tablespace:
+-- Name: settings_object_id_idx; Type: INDEX; Schema: audit; Owner: -; Tablespace: 
 --
 
 CREATE INDEX settings_object_id_idx ON audit.settings USING btree (object_id);
 
 
 --
--- Name: settings_recorded_at_idx; Type: INDEX; Schema: audit; Owner: -; Tablespace:
+-- Name: settings_recorded_at_idx; Type: INDEX; Schema: audit; Owner: -; Tablespace: 
 --
 
 CREATE INDEX settings_recorded_at_idx ON audit.settings USING btree (recorded_at);
 
 
 --
--- Name: users_object_id_idx; Type: INDEX; Schema: audit; Owner: -; Tablespace:
+-- Name: users_object_id_idx; Type: INDEX; Schema: audit; Owner: -; Tablespace: 
 --
 
 CREATE INDEX users_object_id_idx ON audit.users USING btree (object_id);
 
 
 --
--- Name: users_recorded_at_idx; Type: INDEX; Schema: audit; Owner: -; Tablespace:
+-- Name: users_recorded_at_idx; Type: INDEX; Schema: audit; Owner: -; Tablespace: 
 --
 
 CREATE INDEX users_recorded_at_idx ON audit.users USING btree (recorded_at);
 
 
 --
--- Name: wishlist_items_object_id_idx; Type: INDEX; Schema: audit; Owner: -; Tablespace:
+-- Name: wishlist_items_object_id_idx; Type: INDEX; Schema: audit; Owner: -; Tablespace: 
 --
 
 CREATE INDEX wishlist_items_object_id_idx ON audit.wishlist_items USING btree (object_id);
 
 
 --
--- Name: wishlist_items_recorded_at_idx; Type: INDEX; Schema: audit; Owner: -; Tablespace:
+-- Name: wishlist_items_recorded_at_idx; Type: INDEX; Schema: audit; Owner: -; Tablespace: 
 --
 
 CREATE INDEX wishlist_items_recorded_at_idx ON audit.wishlist_items USING btree (recorded_at);
 
 
 --
--- Name: delayed_jobs_priority; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: delayed_jobs_priority; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX delayed_jobs_priority ON public.delayed_jobs USING btree (priority, run_at);
 
 
 --
--- Name: index_auctions_on_domain_name; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_auctions_on_domain_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_auctions_on_domain_name ON public.auctions USING btree (domain_name);
 
 
 --
--- Name: index_auctions_on_ends_at; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_auctions_on_ends_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_auctions_on_ends_at ON public.auctions USING btree (ends_at);
 
 
 --
--- Name: index_auctions_on_remote_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_auctions_on_remote_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_auctions_on_remote_id ON public.auctions USING btree (remote_id);
 
 
 --
--- Name: index_auctions_on_uuid; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_auctions_on_uuid; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_auctions_on_uuid ON public.auctions USING btree (uuid);
 
 
 --
--- Name: index_bans_on_domain_name; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_bans_on_domain_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_bans_on_domain_name ON public.bans USING btree (domain_name);
 
 
 --
--- Name: index_bans_on_invoice_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_bans_on_invoice_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_bans_on_invoice_id ON public.bans USING btree (invoice_id);
 
 
 --
--- Name: index_bans_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_bans_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_bans_on_user_id ON public.bans USING btree (user_id);
 
 
 --
--- Name: index_billing_profiles_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_billing_profiles_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_billing_profiles_on_user_id ON public.billing_profiles USING btree (user_id);
 
 
 --
--- Name: index_billing_profiles_on_uuid; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_billing_profiles_on_uuid; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_billing_profiles_on_uuid ON public.billing_profiles USING btree (uuid);
 
 
 --
--- Name: index_billing_profiles_on_vat_code_and_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_billing_profiles_on_vat_code_and_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_billing_profiles_on_vat_code_and_user_id ON public.billing_profiles USING btree (vat_code, user_id);
 
 
 --
--- Name: index_invoice_items_on_invoice_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_invoice_items_on_invoice_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_invoice_items_on_invoice_id ON public.invoice_items USING btree (invoice_id);
 
 
 --
--- Name: index_invoice_items_on_uuid; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_invoice_items_on_uuid; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_invoice_items_on_uuid ON public.invoice_items USING btree (uuid);
 
 
 --
--- Name: index_invoices_on_billing_profile_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_invoices_on_billing_profile_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_invoices_on_billing_profile_id ON public.invoices USING btree (billing_profile_id);
 
 
 --
--- Name: index_invoices_on_paid_with_payment_order_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_invoices_on_paid_with_payment_order_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_invoices_on_paid_with_payment_order_id ON public.invoices USING btree (paid_with_payment_order_id);
 
 
 --
--- Name: index_invoices_on_result_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_invoices_on_result_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_invoices_on_result_id ON public.invoices USING btree (result_id);
 
 
 --
--- Name: index_invoices_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_invoices_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_invoices_on_user_id ON public.invoices USING btree (user_id);
 
 
 --
--- Name: index_invoices_on_uuid; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_invoices_on_uuid; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_invoices_on_uuid ON public.invoices USING btree (uuid);
 
 
 --
--- Name: index_offers_on_auction_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_offers_on_auction_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_offers_on_auction_id ON public.offers USING btree (auction_id);
 
 
 --
--- Name: index_offers_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_offers_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_offers_on_user_id ON public.offers USING btree (user_id);
 
 
 --
--- Name: index_offers_on_uuid; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_offers_on_uuid; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_offers_on_uuid ON public.offers USING btree (uuid);
 
 
 --
--- Name: index_payment_orders_on_invoice_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_payment_orders_on_invoice_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_payment_orders_on_invoice_id ON public.payment_orders USING btree (invoice_id);
 
 
 --
--- Name: index_payment_orders_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_payment_orders_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_payment_orders_on_user_id ON public.payment_orders USING btree (user_id);
 
 
 --
--- Name: index_payment_orders_on_uuid; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_payment_orders_on_uuid; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_payment_orders_on_uuid ON public.payment_orders USING btree (uuid);
 
 
 --
--- Name: index_results_on_auction_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_results_on_auction_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_results_on_auction_id ON public.results USING btree (auction_id);
 
 
 --
--- Name: index_results_on_last_remote_status; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_results_on_last_remote_status; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_results_on_last_remote_status ON public.results USING btree (last_remote_status);
 
 
 --
--- Name: index_results_on_offer_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_results_on_offer_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_results_on_offer_id ON public.results USING btree (offer_id);
 
 
 --
--- Name: index_results_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_results_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_results_on_user_id ON public.results USING btree (user_id);
 
 
 --
--- Name: index_results_on_uuid; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_results_on_uuid; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_results_on_uuid ON public.results USING btree (uuid);
 
 
 --
--- Name: index_settings_on_code; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_settings_on_code; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_settings_on_code ON public.settings USING btree (code);
 
 
 --
--- Name: index_statistics_report_auctions_on_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_statistics_report_auctions_on_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_statistics_report_auctions_on_id ON public.statistics_report_auctions USING btree (id);
 
 
 --
--- Name: index_statistics_report_invoices_on_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_statistics_report_invoices_on_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_statistics_report_invoices_on_id ON public.statistics_report_invoices USING btree (id);
 
 
 --
--- Name: index_statistics_report_results_on_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_statistics_report_results_on_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_statistics_report_results_on_id ON public.statistics_report_results USING btree (id);
 
 
 --
--- Name: index_users_on_confirmation_token; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_users_on_confirmation_token; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_users_on_confirmation_token ON public.users USING btree (confirmation_token);
 
 
 --
--- Name: index_users_on_email; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_users_on_email; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_users_on_email ON public.users USING btree (email);
 
 
 --
--- Name: index_users_on_provider_and_uid; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_users_on_provider_and_uid; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_users_on_provider_and_uid ON public.users USING btree (provider, uid);
 
 
 --
--- Name: index_users_on_reset_password_token; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_users_on_reset_password_token; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_users_on_reset_password_token ON public.users USING btree (reset_password_token);
 
 
 --
--- Name: index_users_on_uuid; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_users_on_uuid; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX index_users_on_uuid ON public.users USING btree (uuid);
 
 
 --
--- Name: index_wishlist_items_on_domain_name; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: index_wishlist_items_on_domain_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_wishlist_items_on_domain_name ON public.wishlist_items USING btree (domain_name);
 
 
 --
--- Name: users_by_identity_code_and_country; Type: INDEX; Schema: public; Owner: -; Tablespace:
+-- Name: users_by_identity_code_and_country; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE UNIQUE INDEX users_by_identity_code_and_country ON public.users USING btree (alpha_two_country_code, identity_code) WHERE ((alpha_two_country_code)::text = 'EE'::text);
@@ -2466,4 +2467,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20191209073454'),
 ('20191209083000'),
 ('20191209085222'),
-('20191213082941');
+('20191213082941'),
+('20191220131845');
+
+

--- a/lib/tasks/data_migrations/create_extension_whitelist.rake
+++ b/lib/tasks/data_migrations/create_extension_whitelist.rake
@@ -9,6 +9,7 @@ namespace :data_migrations do
     domain_extensions = Setting.new(
       code: :wishlist_supported_domain_extensions,
       value: extensions,
+      value_format: 'array',
       description: domain_extensions_description
     )
     domain_extensions.save!

--- a/lib/tasks/data_migrations/set_correct_setting_formats.rake
+++ b/lib/tasks/data_migrations/set_correct_setting_formats.rake
@@ -1,0 +1,27 @@
+namespace :data_migrations do
+  desc 'Set correct format attribute for existing settings'
+  task set_correct_setting_formats: :environment do
+    boolean_settings = %w[require_phone_confirmation]
+    integer_settings = %w[auction_minimum_offer payment_term registration_term
+                          ban_length ban_number_of_strikes
+                          invoice_reminder_in_days wishlist_size domain_registration_reminder]
+    string_settings = %w[auction_currency default_country invoice_issuer check_api_url check_sms_url
+                         check_tara_url auction_duration auctions_start_at]
+    hash_settings = %w[violations_count_regulations_link terms_and_conditions_link]
+    arr_settings = %w[wishlist_supported_domain_extensions]
+
+    Setting.all.each do |stng|
+      stng.value_format = 'boolean' if boolean_settings.include? stng.code
+      stng.value_format = 'integer' if integer_settings.include? stng.code
+      stng.value_format = 'string' if string_settings.include? stng.code
+      stng.value_format = 'hash' if hash_settings.include? stng.code
+      stng.value_format = 'array' if arr_settings.include? stng.code
+
+      if stng.save
+        puts "#{stng.code} data format set to: '#{stng.value_format}'"
+      else
+        puts "Failed to set data format for '#{stng.code}'"
+      end
+    end
+  end
+end

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -2,6 +2,7 @@ application_name:
   code: application_name
   description: Application name, as displayed in the header
   value: EIS Auction Center
+  value_format: string
 
 auction_currency:
   code: auction_currency
@@ -9,11 +10,13 @@ auction_currency:
     Currency in which all invoices and offers are to be made. Allowed values are
     EUR, USD, CAD, AUD, GBP, PLN, SEK. Default is: EUR
   value: EUR
+  value_format: string
 
 auction_minimum_offer:
   code: auction_minimum_offer
   description: 'Minimum amount in cents that a user can offer for a domain. Default is: 500 (5.00 EUR)'
   value: '500'
+  value_format: integer
 
 terms_and_conditions_link:
   code: terms_and_conditions_link
@@ -23,6 +26,7 @@ terms_and_conditions_link:
     or absolute ('https://example.com/terms_and_conditions.pdf'). Relative URL must start with a
     forward slash. Default is: "{\"en\":\"https://example.com\"}"
   value: "{\"en\":\"https://example.com\"}"
+  value_format: hash
 
 violations_count_regulations_link:
   code: violations_count_regulations_link
@@ -34,6 +38,7 @@ violations_count_regulations_link:
     forward slash.
     Default: https://example.com#some_anchor
   value: "{\"en\":\"https://example.com#some_anchor\"}"
+  value_format: hash
 
 default_country:
   code: default_country
@@ -41,6 +46,7 @@ default_country:
     Alpha two code for default country, used for example in user and billing profile dropdowns.
     Example values: "EE", "GB", "US", "CA"
   value: EE
+  value_format: string
 
 payment_term:
   code: payment_term
@@ -49,6 +55,7 @@ payment_term:
     If invoices are generated at the start of a day you might want to substract 1 from the
     setting to achieve desired invoice due date. Default: 7
   value: 7
+  value_format: integer
 
 require_phone_confirmation:
   code: require_phone_confirmation
@@ -56,6 +63,7 @@ require_phone_confirmation:
     Require mobile numbers to be confirmed by SMS before user can place offers. Can be either 'true'
     or 'false'
   value: "false"
+  value_format: boolean
 
 auction_duration:
   code: auction_duration
@@ -63,6 +71,7 @@ auction_duration:
     Number of hours for which an auction is created. You can also use 'end_of_day'
     for auctions to end at the end of the same calendar day. Default: 24.
   value: '24'
+  value_format: string
 
 registration_term:
   code: registration_term
@@ -70,6 +79,7 @@ registration_term:
     Number of days before the auctioned domain must be registered, starting from release of
     registration code. Default: 14
   value: '14'
+  value_format: integer
 
 auctions_start_at:
   code: 'auctions_start_at'
@@ -77,24 +87,28 @@ auctions_start_at:
     Whole hour at which auctions should start. Allowed values are anything between 0 and 23 or
     'false'. In case 'false' is used, auctions are started as soon as possible.
   value: '0'
+  value_format: string
 
 ban_length:
   code: 'ban_length'
   description: |
     Number of months for which a repeated offender is banned for. Default: 100
   value: '100'
+  value_format: integer
 
 ban_number_of_strikes:
   code: 'ban_number_of_strikes'
   description: |
     Number of strikes (unpaid invoices) at which a long ban is applied. Default: 3
   value: '3'
+  value_format: integer
 
 domain_registration_reminder:
   code: 'domain_registration_reminder'
   description: |
     Number of days before which the registration reminder email is sent on. Default: 5
   value: '5'
+  value_format: integer
 
 invoice_issuer:
   code: 'invoice_issuer'
@@ -102,6 +116,7 @@ invoice_issuer:
     Text that should appear in invoice as issuer. Usually contains company name, VAT number and
     local court registration number.e which the registration reminder email is sent on. Default: 5
   value: 'Eesti Interneti SA, VAT number EE101286464'
+  value_format: string
 
 invoice_reminder_in_days:
   code: 'invoice_reminder_in_days'
@@ -109,9 +124,42 @@ invoice_reminder_in_days:
     Number of days before due date on which reminders about unpaid invoices are sent.
     Use 0 to send reminders on due date. Default: 1
   value: '1'
+  value_format: integer
 
 wishlist_size:
   code: 'wishlist_size'
   description: |
     Number of domains a single user can keep in their wishlist. Default: 10
   value: '10'
+  value_format: integer
+
+wishlist_supported_domain_extensions:
+  code: 'wishlist_supported_domain_extensions'
+  description: |
+    Supported domain extensions for wishlist domain monitoring.
+  value: '[]'
+  value_format: array
+
+check_api_url:
+  code: 'check_api_url'
+  description: |
+    URL to our own auction API endpoint for health checking.
+    Must be absolute, default is http://localhost/auctions.json.
+  value: 'http://localhost/auctions.json'
+  value_format: string
+
+check_sms_url:
+  code: 'check_sms_url'
+  description: |
+    URL of SMS service provider for health checking.
+    Must be absolute.
+  value: 'https://status.messente.com/api/v1/components/1'
+  value_format: string
+
+check_tara_url:
+  code: 'check_tara_url'
+  description: |
+    URL of OAUTH Tara provider for health checking.
+    Must be absolute.
+  value: 'https://tara-test.ria.ee/oidc/jwks'
+  value_format: string

--- a/test/jobs/unpaid_invoice_reminder_job_test.rb
+++ b/test/jobs/unpaid_invoice_reminder_job_test.rb
@@ -5,7 +5,7 @@ class UnpaidInvoiceReminderJobTest < ActiveJob::TestCase
     super
 
     @invoice = invoices(:payable)
-    travel_to(@invoice.due_date - Setting.invoice_reminder_in_days)
+    travel_to(@invoice.due_date - Setting.find_by(code: 'invoice_reminder_in_days').retrieve)
     clear_email_deliveries
   end
 

--- a/test/models/admin_auction_decorator_test.rb
+++ b/test/models/admin_auction_decorator_test.rb
@@ -39,6 +39,6 @@ class AdminAuctionDecoratorTest < ActiveSupport::TestCase
     decorated_auction = AdminAuctionDecorator.new(
       auctions.find_by(auctions: { domain_name: 'with-offers.test' })
     )
-    assert_equal(Money.new(5000, Setting.auction_currency), decorated_auction.highest_price)
+    assert_equal(Money.new(5000, Setting.find_by(code: 'auction_currency').retrieve), decorated_auction.highest_price)
   end
 end

--- a/test/models/audit/invoice_audit_test.rb
+++ b/test/models/audit/invoice_audit_test.rb
@@ -21,7 +21,7 @@ class InvoiceAuditTest < ActiveSupport::TestCase
                           billing_profile: @billing_profile,
                           user: @user,
                           issue_date: Time.zone.today,
-                          due_date: Time.zone.today + Setting.payment_term,
+                          due_date: Time.zone.today + Setting.find_by(code: 'payment_term').retrieve,
                           cents: 1000)
 
     invoice.save!

--- a/test/models/automatic_ban_test.rb
+++ b/test/models/automatic_ban_test.rb
@@ -126,7 +126,7 @@ class AutomaticBanTest < ActiveSupport::TestCase
     travel_back
     travel_to(auction.starts_at + 1) do
       Offer.create!(auction: auction,
-                    cents: rand(1000) + Setting.auction_minimum_offer,
+                    cents: rand(1000) + Setting.find_by(code: 'auction_minimum_offer').retrieve,
                     user: user, billing_profile: user.billing_profiles.sample)
     end
 

--- a/test/models/invoice_cancellation_test.rb
+++ b/test/models/invoice_cancellation_test.rb
@@ -24,7 +24,7 @@ class InvoiceCancellationTest < ActiveSupport::TestCase
     invoice.billing_profile = @company_billing_profile
     invoice.user = @user
     invoice.issue_date = Time.zone.today
-    invoice.due_date = Time.zone.today + Setting.payment_term
+    invoice.due_date = Time.zone.today + Setting.find_by(code: 'payment_term').retrieve
     invoice.cents = 1000
 
     invoice

--- a/test/models/invoice_test.rb
+++ b/test/models/invoice_test.rb
@@ -22,10 +22,10 @@ class InvoiceTest < ActiveSupport::TestCase
   def test_price_is_a_money_object
     invoice = Invoice.new(cents: 1000)
 
-    assert_equal(Money.new(1000, Setting.auction_currency), invoice.price)
+    assert_equal(Money.new(1000, Setting.find_by(code: 'auction_currency').retrieve), invoice.price)
 
     invoice.cents = nil
-    assert_equal(Money.new(0, Setting.auction_currency), invoice.price)
+    assert_equal(Money.new(0, Setting.find_by(code: 'auction_currency').retrieve), invoice.price)
   end
 
   def test_required_fields
@@ -42,7 +42,7 @@ class InvoiceTest < ActiveSupport::TestCase
     invoice.billing_profile = @company_billing_profile
     invoice.user = @user
     invoice.issue_date = Time.zone.today
-    invoice.due_date = Time.zone.today + Setting.payment_term
+    invoice.due_date = Time.zone.today + Setting.find_by(code: 'payment_term').retrieve
     invoice.cents = 1000
 
     assert(invoice.valid?)
@@ -184,7 +184,7 @@ class InvoiceTest < ActiveSupport::TestCase
     invoice.billing_profile = @company_billing_profile
     invoice.user = @user
     invoice.issue_date = Time.zone.today
-    invoice.due_date = Time.zone.today + Setting.payment_term
+    invoice.due_date = Time.zone.today + Setting.find_by(code: 'payment_term').retrieve
     invoice.cents = 1000
 
     invoice

--- a/test/models/participant_auction_decorator_test.rb
+++ b/test/models/participant_auction_decorator_test.rb
@@ -40,6 +40,6 @@ class ParticipantAuctionDecoratorTest < ActiveSupport::TestCase
     decorated_auction = ParticipantAuctionDecorator.new(
       auctions.find_by(auctions: { domain_name: 'with-offers.test' })
     )
-    assert_equal(Money.new(5000, Setting.auction_currency), decorated_auction.users_price)
+    assert_equal(Money.new(5000, Setting.find_by(code: 'auction_currency').retrieve), decorated_auction.users_price)
   end
 end

--- a/test/models/payment_orders/payment_order_estonian_bank_link_test.rb
+++ b/test/models/payment_orders/payment_order_estonian_bank_link_test.rb
@@ -27,8 +27,8 @@ class PaymentOrderEstonianBankLinkTest < ActiveSupport::TestCase
   end
 
   def test_form_fields
-    @orphaned_invoice.cents = Money.from_amount(1000.00, Setting.auction_currency).cents
-    assert_equal Money.from_amount(1200.00, Setting.auction_currency), @orphaned_invoice.total
+    @orphaned_invoice.cents = Money.from_amount(1000.00, Setting.find_by(code: 'auction_currency').retrieve).cents
+    assert_equal Money.from_amount(1200.00, Setting.find_by(code: 'auction_currency').retrieve), @orphaned_invoice.total
 
     expected_fields = {
       'VK_SERVICE': '1012',
@@ -70,8 +70,8 @@ class PaymentOrderEstonianBankLinkTest < ActiveSupport::TestCase
 
   def test_user_locale_is_mapped_to_vk_lang
     @new_bank_link.user = @user
-    @orphaned_invoice.cents = Money.from_amount(1234.56, Setting.auction_currency).cents
-    assert_equal Money.from_amount(1481.47, Setting.auction_currency), @orphaned_invoice.total
+    @orphaned_invoice.cents = Money.from_amount(1234.56, Setting.find_by(code: 'auction_currency').retrieve).cents
+    assert_equal Money.from_amount(1481.47, Setting.find_by(code: 'auction_currency').retrieve), @orphaned_invoice.total
     @user.update!(locale: :et)
 
     expected_fields = {

--- a/test/models/payment_orders/payment_order_every_pay_test.rb
+++ b/test/models/payment_orders/payment_order_every_pay_test.rb
@@ -51,8 +51,8 @@ class PaymentOrderEveryPayTest < ActiveSupport::TestCase
   end
 
   def test_form_fields_are_filled_according_to_schema
-    @orphaned_invoice.cents = Money.from_amount(1000.00, Setting.auction_currency).cents
-    assert_equal Money.from_amount(1200.00, Setting.auction_currency), @orphaned_invoice.total
+    @orphaned_invoice.cents = Money.from_amount(1000.00, Setting.find_by(code: 'auction_currency').retrieve).cents
+    assert_equal Money.from_amount(1200.00, Setting.find_by(code: 'auction_currency').retrieve), @orphaned_invoice.total
 
     expected_fields = {
       api_username: 'api_user',
@@ -71,8 +71,8 @@ class PaymentOrderEveryPayTest < ActiveSupport::TestCase
 
   def test_form_fields_with_estonian_locale
     @every_pay.user = @user
-    @orphaned_invoice.cents = Money.from_amount(1234.56, Setting.auction_currency).cents
-    assert_equal Money.from_amount(1481.47, Setting.auction_currency), @orphaned_invoice.total
+    @orphaned_invoice.cents = Money.from_amount(1234.56, Setting.find_by(code: 'auction_currency').retrieve).cents
+    assert_equal Money.from_amount(1481.47, Setting.find_by(code: 'auction_currency').retrieve), @orphaned_invoice.total
     @user.update!(locale: :et)
 
     expected_fields = {

--- a/test/models/setting_test.rb
+++ b/test/models/setting_test.rb
@@ -32,51 +32,18 @@ class SettingTest < ActiveSupport::TestCase
     assert_equal(['has already been taken'], new_subject.errors[:code])
   end
 
-  def test_class_methods_are_shorthand_for_values
-    assert_equal('EUR', Setting.auction_currency)
-    assert_equal(500, Setting.auction_minimum_offer)
-
-    assert_equal('https://example.com', Setting.terms_and_conditions_link)
-    assert_equal('EE', Setting.default_country)
-
-    assert_equal(7, Setting.payment_term)
-    assert_equal(14, Setting.registration_term)
-
-    assert_equal(false, Setting.require_phone_confirmation)
-
-    assert_equal(24, Setting.auction_duration)
-    Setting.find_by(code: :auction_duration).update(value: 'end_of_day')
-    assert_equal(:end_of_day, Setting.auction_duration)
-
-    assert_equal(0, Setting.auctions_start_at)
-
-    Setting.find_by(code: :auctions_start_at).update(value: 'false')
-    assert_equal(false, Setting.auctions_start_at)
-
-    assert_equal(100, Setting.ban_length)
-    assert_equal(3, Setting.ban_number_of_strikes)
-
-    assert_equal(5, Setting.domain_registration_reminder_day)
-    assert_equal(1, Setting.invoice_reminder_in_days)
-
-    assert_equal('Eesti Interneti SA, VAT number EE101286464', Setting.invoice_issuer)
-
-    assert_equal(10, Setting.wishlist_size)
-  end
-
   def test_terms_and_conditions_parsing_and_multilocale
     Setting.find_by(code: :terms_and_conditions_link).update!(value: "{\"en\":\"https://example.com\", \"et\":\"https://example.et\"}")
-    assert_equal('https://example.com', Setting.terms_and_conditions_link)
+    assert_equal('https://example.com', Setting.find_by(code: 'terms_and_conditions_link').retrieve)
   end
 
   def test_multilocale_violations_count_regulations_link
     Setting.find_by(code: :violations_count_regulations_link).update!(value: "{\"en\":\"https://regulations.test#some_anchor\"}")
-    assert_equal('https://regulations.test#some_anchor', Setting.violations_count_regulations_link)
+    assert_equal('https://regulations.test#some_anchor', Setting.find_by(code: 'violations_count_regulations_link').retrieve)
   end
 
   def test_valid_format_for_wishlist_domain_extension_setting
-    @setting = settings(:application_name)
-    @setting.code = 'wishlist_supported_domain_extensions'
+    @setting = settings(:wishlist_supported_domain_extensions)
     @setting.value = '["ee", "pri.ee"]'
     assert @setting.valid?
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -14,7 +14,7 @@ class UserTest < ActiveSupport::TestCase
     assert_equal(["can't be blank"], user.errors[:password])
     assert_equal(["can't be blank"], user.errors[:email])
     assert_equal(["can't be blank", 'is invalid'], user.errors[:mobile_phone])
-    assert_equal(['must be accepted'], user.errors[:terms_and_conditions])
+    assert_equal(['Terms and conditions must be accepted'], user.errors[:terms_and_conditions])
     assert_equal(["can't be blank"], user.errors[:given_names])
     assert_equal(["can't be blank"], user.errors[:surname])
 

--- a/test/models/wishlist_item_test.rb
+++ b/test/models/wishlist_item_test.rb
@@ -75,8 +75,8 @@ class WishlistItemTest < ActiveSupport::TestCase
 
   def test_domain_has_valid_extension
     supported_extensions = ["ee"]
-    setting = settings(:application_name)
-    setting.update!(code: :wishlist_supported_domain_extensions, value: supported_extensions)
+    setting = settings(:wishlist_supported_domain_extensions)
+    setting.update!(value: supported_extensions)
 
     item = WishlistItem.new(user: @user, domain_name: 'dupe.ee')
     assert(item.valid?)

--- a/test/system/admin/users/admin_users_list_test.rb
+++ b/test/system/admin/users/admin_users_list_test.rb
@@ -56,7 +56,7 @@ class AdminUsersListTest < ApplicationSystemTestCase
 
   def test_form_has_terms_and_conditions_link
     visit new_admin_user_path
-    assert(page.has_link?('auction portal user agreement', href: Setting.terms_and_conditions_link))
+    assert(page.has_link?('auction portal user agreement', href: Setting.find_by(code: 'terms_and_conditions_link').retrieve))
   end
 
   def test_certain_fields_are_required

--- a/test/system/auctions_test.rb
+++ b/test/system/auctions_test.rb
@@ -72,7 +72,7 @@ class AuctionsTest < ApplicationSystemTestCase
                      href: 'https://www.internet.ee/help-and-info/faq#III__ee_domain_auctions')
     )
 
-    assert(page.has_link?('terms and conditions', href: Setting.terms_and_conditions_link))
+    assert(page.has_link?('terms and conditions', href: Setting.find_by(code: 'terms_and_conditions_link').retrieve))
   end
 
   def test_auctions_index_does_not_contain_auctions_that_are_finished

--- a/test/system/users/create_user_test.rb
+++ b/test/system/users/create_user_test.rb
@@ -51,7 +51,7 @@ class CreateUserTest < ApplicationSystemTestCase
 
   def test_form_has_terms_and_conditions_link
     visit new_user_path
-    assert(page.has_link?('auction portal user agreement', href: Setting.terms_and_conditions_link))
+    assert(page.has_link?('auction portal user agreement', href: Setting.find_by(code: 'terms_and_conditions_link').retrieve))
   end
 
   def test_terms_and_conditions_link_can_also_be_relative

--- a/test/system/users/delete_user_test.rb
+++ b/test/system/users/delete_user_test.rb
@@ -1,12 +1,6 @@
 require 'application_system_test_case'
 
 class DeleteUserTest < ApplicationSystemTestCase
-  def setup
-    super
-
-    @user = users(:participant)
-    sign_in(@user)
-  end
 
   def teardown
     super
@@ -14,7 +8,23 @@ class DeleteUserTest < ApplicationSystemTestCase
     clear_email_deliveries
   end
 
-  def test_a_user_can_delete_their_own_account
+  def test_a_user_cannot_delete_their_own_account_if_invoice_issued
+    @user = users(:participant)
+    sign_in(@user)
+    visit user_path(@user.uuid)
+
+    assert(page.has_link?('Delete account'))
+
+    accept_confirm do
+      click_link_or_button('Delete account')
+    end
+
+    assert_text('Your account cannot be deleted because you got unpaid invoices.')
+  end
+
+  def test_a_user_can_delete_their_own_account_if_no_invoice_issued
+    @user = users(:second_place_participant)
+    sign_in(@user)
     visit user_path(@user.uuid)
 
     assert(page.has_link?('Delete account'))

--- a/test/system/users/edit_user_test.rb
+++ b/test/system/users/edit_user_test.rb
@@ -161,6 +161,6 @@ class EditUserTest < ApplicationSystemTestCase
 
   def test_profile_page_has_a_link_to_terms_and_conditions
     visit user_path(@user.uuid)
-    assert(page.has_link?('Review terms and condition', href: Setting.terms_and_conditions_link))
+    assert(page.has_link?('Review terms and condition', href: Setting.find_by(code: 'terms_and_conditions_link').retrieve))
   end
 end

--- a/test/system/users/tara_users_test.rb
+++ b/test/system/users/tara_users_test.rb
@@ -48,7 +48,7 @@ class TaraUsersTest < ApplicationSystemTestCase
 
     fill_in('user[email]', with: 'new-user@auction.test')
     check_checkbox('user[accepts_terms_and_conditions]')
-    assert(page.has_link?('auction portal user agreement', href: Setting.terms_and_conditions_link))
+    assert(page.has_link?('auction portal user agreement', href: Setting.find_by(code: 'terms_and_conditions_link').retrieve))
 
     click_link_or_button('Sign up')
     assert(page.has_css?('div.alert', text: 'You have to confirm your email address before continuing'))

--- a/yarn.lock
+++ b/yarn.lock
@@ -1926,15 +1926,10 @@ commander@2.12.2:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.12.2.tgz#0f5946c427ed9ec0d91a46bb9def53e54650e555"
   integrity sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==
 
-commander@^2.20.0:
+commander@^2.20.0, commander@~2.20.3:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
-
-commander@~2.17.1:
-  version "2.17.1"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
-  integrity sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==
 
 commondir@^1.0.1:
   version "1.0.1"
@@ -3514,9 +3509,9 @@ handle-thing@^2.0.0:
   integrity sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ==
 
 handlebars@^4.0.1:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.2.tgz#b6b37c1ced0306b221e094fc7aca3ec23b131b67"
-  integrity sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.5.3.tgz#5cf75bd8714f7605713511a56be7c349becb0482"
+  integrity sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==
   dependencies:
     neo-async "^2.6.0"
     optimist "^0.6.1"
@@ -7910,11 +7905,11 @@ typeface-raleway@^0.0.75:
   integrity sha512-mUvT/klCTGA2HporaIMNY3ap45YxBErxFv/1pv82LhbFdNc3m+6ddfoexP6xxwMZ5yZ2VmDhMqk1yikDEoxU/Q==
 
 uglify-js@^3.1.4:
-  version "3.4.9"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.4.9.tgz#af02f180c1207d76432e473ed24a28f4a782bae3"
-  integrity sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.7.3.tgz#f918fce9182f466d5140f24bb0ff35c2d32dcc6a"
+  integrity sha512-7tINm46/3puUA4hCkKYo4Xdts+JDaVC9ZPRcG8Xw9R4nhO/gZgUM3TENq8IF4Vatk8qCig4MzP/c8G4u2BkVQg==
   dependencies:
-    commander "~2.17.1"
+    commander "~2.20.3"
     source-map "~0.6.1"
 
 ultron@~1.1.0:


### PR DESCRIPTION
Closes #382 

- Every setting is now required to have `value_format` which defaults to `string`. Available formats are `string`, `boolean`, `integer`, `hash`, ` array`

- Settings are no longer accessed via Setting.setting_name because it has too many redundant methods.

- Each invidual setting must be retrieved via `Setting.find_by(code: :setting_code).retrieve`. It has same output as previous querying via class method.

`data_migrations:set_correct_setting_formats` rake task must be ran to set correct format for already existing settings.