### PR TITLE
Add custom field vaildation for users & profiles

### DIFF
--- a/app/controllers/auth/sessions_controller.rb
+++ b/app/controllers/auth/sessions_controller.rb
@@ -1,7 +1,9 @@
 module Auth
   class SessionsController < Devise::SessionsController
     include BansHelper
+    include InvalidUserDataHelper
     after_action :set_ban_in_session, only: [:create]
+    after_action :set_invalid_data_flag_in_session, only: [:create]
 
     def create
       super

--- a/app/helpers/invalid_user_data_helper.rb
+++ b/app/helpers/invalid_user_data_helper.rb
@@ -1,0 +1,23 @@
+module InvalidUserDataHelper
+  def set_invalid_data_flag_in_session
+    return unless current_user
+
+    session['user.invalid_user_data'] = user_data_invalid?
+  end
+
+  def invalid_data_banner
+    return unless session['user.invalid_user_data']
+
+    content_tag(:div, class: 'ui message ban') do
+      content_tag(:div, t('users.invalid_user_data'), class: 'header')
+    end
+  end
+
+  private
+
+  def user_data_invalid?
+    current_user.invalid? &&
+      current_user.errors.keys.any? { |key| %i[given_names surname].include?(key) } ||
+      (current_user.billing_profiles.present? && current_user.billing_profiles.any?(&:invalid?))
+  end
+end

--- a/app/models/billing_profile.rb
+++ b/app/models/billing_profile.rb
@@ -7,6 +7,8 @@ class BillingProfile < ApplicationRecord
   validates :country_code, presence: true
   validates :vat_code, uniqueness: { scope: :user_id }, allow_blank: true
 
+  validates :name, :vat_code, :street, :city, :postal_code, safe_value: true
+
   belongs_to :user, optional: true
   after_update :mirror_address_to_attached_invoices
 

--- a/app/models/concerns/safe_value_validator.rb
+++ b/app/models/concerns/safe_value_validator.rb
@@ -1,0 +1,11 @@
+class SafeValueValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return true if value.blank?
+
+    if %r{[^a-zA-Z\/\d\s\/\'\-]}.match?(value)
+      record.errors.add(attribute, :invalid)
+      return false
+    end
+    true
+  end
+end

--- a/app/models/concerns/safe_value_validator.rb
+++ b/app/models/concerns/safe_value_validator.rb
@@ -2,7 +2,9 @@ class SafeValueValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     return true if value.blank?
 
-    if %r{[^a-zA-Z\/\d\s\/\'\-]}.match?(value)
+    # Regexp for estonian unicode characters lower/upper-case
+    unicode_chars = /\u00E4\u00C4\u00F5\u00D5\u00F6\u00D6\u00FC\u00DC\u0161\u0160\u017E\u017D/
+    if %r{[^a-zA-Z#{unicode_chars.source}\/\d\s\/\'\-]}.match?(value)
       record.errors.add(attribute, :invalid)
       return false
     end

--- a/app/models/concerns/safe_value_validator.rb
+++ b/app/models/concerns/safe_value_validator.rb
@@ -4,8 +4,8 @@ class SafeValueValidator < ActiveModel::EachValidator
 
     # Regexp for estonian unicode characters lower/upper-case
     unicode_chars = /\u00E4\u00C4\u00F5\u00D5\u00F6\u00D6\u00FC\u00DC\u0161\u0160\u017E\u017D/
-    if %r{[^a-zA-Z#{unicode_chars.source}\/\d\s\/\'\-]}.match?(value)
-      record.errors.add(attribute, :invalid)
+    if %r{[^a-zA-Z#{unicode_chars.source}\/\d\s\/\'\-\.]}.match?(value)
+      record.errors.add(attribute, I18n.t('.value_is_not_safe'))
       return false
     end
     true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,6 +24,8 @@ class User < ApplicationRecord
     user.provider == TARA_PROVIDER
   }
 
+  validates :given_names, :surname, safe_value: true
+
   validates :given_names, presence: true
   validates :surname, presence: true
   validate :participant_must_accept_terms_and_conditions

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,6 +40,12 @@ class User < ApplicationRecord
 
   scope :subscribed_to_daily_summary, -> { where(daily_summary: true) }
 
+  def identity_code_must_be_valid_for_estonia
+    return if IdentityCode.new(country_code, identity_code).valid?
+
+    errors.add(:identity_code, I18n.t(:is_invalid))
+  end
+
   def participant_must_accept_terms_and_conditions
     return if terms_and_conditions_accepted_at.present?
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,12 +40,6 @@ class User < ApplicationRecord
 
   scope :subscribed_to_daily_summary, -> { where(daily_summary: true) }
 
-  def identity_code_must_be_valid_for_estonia
-    return if IdentityCode.new(country_code, identity_code).valid?
-
-    errors.add(:identity_code, I18n.t(:is_invalid))
-  end
-
   def participant_must_accept_terms_and_conditions
     return if terms_and_conditions_accepted_at.present?
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,6 +30,7 @@
                 <% end %>
 
                 <%= banned_banner %>
+                <%= invalid_data_banner %>
 
                 <%= yield %>
             </main>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -69,7 +69,7 @@ Rails.application.configure do
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
-  config.i18n.fallbacks = true
+  config.i18n.fallbacks = false
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify

--- a/config/locales/billing_profiles.en.yml
+++ b/config/locales/billing_profiles.en.yml
@@ -33,4 +33,12 @@ en:
         billing_profile:
           attributes:
             name:
-              format: "%{message}"
+              format: "%{attribute}: %{message}"
+            vat_code:
+              format: "%{attribute}: %{message}"
+            city:
+              format: "%{attribute}: %{message}"
+            street:
+              format: "%{attribute}: %{message}"
+            postal_code:
+              format: "%{attribute}: %{message}"

--- a/config/locales/billing_profiles.et.yml
+++ b/config/locales/billing_profiles.et.yml
@@ -45,4 +45,12 @@ et:
           billing_profile:
             attributes:
               name:
-                format: "%{message}"
+                format: "%{attribute}: %{message}"
+              vat_code:
+                format: "%{attribute}: %{message}"
+              city:
+                format: "%{attribute}: %{message}"
+              street:
+                format: "%{attribute}: %{message}"
+              postal_code:
+                format: "%{attribute}: %{message}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -80,6 +80,9 @@ en:
 
   is_invalid: "is invalid"
   invalid: "invalid"
+  value_is_not_safe: |
+    Please, note, what the only characters allowed is utf-characters of english/estonian alphabet,
+    numbers, forward slashes, apostrophes, dots and hyphens
   not_accepted: "Not accepted"
   details: "Details"
   updated_by: "Updated by"

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -67,6 +67,9 @@ et:
 
   is_invalid: "vale"
   invalid: "vale"
+  value_is_not_safe: |
+    Nime ja aadressi andmetes on lubatud kasutada vaid inglise ja eesti tähestiku tähti, numbreid,
+    punkti, ülakoma ning kald- ja sidekriipsu
   not_accepted: "Tagasi lükatud"
   details: "Detailid"
 

--- a/config/locales/users.en.yml
+++ b/config/locales/users.en.yml
@@ -22,6 +22,7 @@ en:
     email_changed: >-
       Confirmation link was sent to new email address. Please confirm the address for the change to
       take an effect!
+    invalid_user_data: "We have detected some invalid characters in your user account data or billing profile. Please review and fix your profile data!"
 
     edit:
       title: "Edit your user profile"

--- a/config/locales/users.en.yml
+++ b/config/locales/users.en.yml
@@ -86,6 +86,10 @@ en:
           attributes:
             terms_and_conditions:
               format: "%{message}"
+            given_names:
+              format: "%{attribute}: %{message}"
+            surname:
+              format: "%{attribute}: %{message}"
 
     attributes:
       user:

--- a/config/locales/users.et.yml
+++ b/config/locales/users.et.yml
@@ -79,6 +79,10 @@ et:
           attributes:
             terms_and_conditions:
               format: "%{message}"
+            given_names:
+              format: "%{attribute}: %{message}"
+            surname:
+              format: "%{attribute}: %{message}"
 
     attributes:
       user:

--- a/config/locales/users.et.yml
+++ b/config/locales/users.et.yml
@@ -22,6 +22,7 @@ et:
     email_changed: >-
       Palun kinnita eposti aadressi muutus klõpsates uuele aadressile saadetud ekirjas olevale
       kinnituse lingile.
+    invalid_user_data: "Tuvastasime teie kasutajakonto või arve profiili väärtustes lubamatuid märke. Palun parandage oma andmed!"
 
     edit:
       title: "Muuda kasutajaprofiili"

--- a/test/models/billing_profile_test.rb
+++ b/test/models/billing_profile_test.rb
@@ -24,6 +24,17 @@ class BillingProfileTest < ActiveSupport::TestCase
     assert(billing_profile.valid?)
   end
 
+  def test_does_not_accept_invalid_values
+    billing_profile = BillingProfile.new
+    billing_profile.name = '"><svg/onload=confirm(1)>'
+    billing_profile.vat_code = "'-sleep(10)#"
+    billing_profile.street = '{7*7}23x23${7*7}'
+    billing_profile.city = '{{7*7}}'
+    billing_profile.postal_code = '{{7*7}}'
+    billing_profile.country_code = 'GB'
+    assert_not(billing_profile.valid?)
+  end
+
   def test_vat_codes_must_be_unique_per_user
     duplicate = @billing_profile.dup
 

--- a/test/models/concerns/safe_value_validator_test.rb
+++ b/test/models/concerns/safe_value_validator_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+
+class SafeValueValidatorTest < ActiveSupport::TestCase
+
+  def setup
+    @user = User.new
+    @user.surname = '"><svg/onload=confirm(1)>'
+    @user.given_names = 'Given Names'
+  end
+
+  def test_false_on_invalid_values
+    validator = SafeValueValidator.new({attributes: {surname: @user.surname}})
+    assert_not(validator.validate_each(@user, :surname, @user.surname))
+  end
+
+  def test_true_on_valid_values
+    validator = SafeValueValidator.new({attributes: {given_names: @user.given_names}})
+    assert(validator.validate_each(@user, :given_names, @user.given_names))
+  end
+end

--- a/test/models/concerns/safe_value_validator_test.rb
+++ b/test/models/concerns/safe_value_validator_test.rb
@@ -5,7 +5,7 @@ class SafeValueValidatorTest < ActiveSupport::TestCase
   def setup
     @user = User.new
     @user.surname = '"><svg/onload=confirm(1)>'
-    @user.given_names = 'Given Names'
+    @user.given_names = 'Given Names ÖÄÕÜüõöä'
   end
 
   def test_false_on_invalid_values

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -78,6 +78,21 @@ class UserTest < ActiveSupport::TestCase
     assert(user.valid?)
   end
 
+  def test_does_not_accept_invalid_values
+    user = User.new
+
+    user.surname = '"><svg/onload=confirm(1)>'
+    user.given_names = '-sleep(10)#'
+    user.email = 'email@example.com'
+    user.password = 'email@example.com'
+    user.password_confirmation = 'email@example.com'
+    user.mobile_phone = '+372500100300'
+    user.country_code = 'PL'
+    user.accepts_terms_and_conditions = 'true'
+
+    assert_not(user.valid?)
+  end
+
   def test_can_be_banned
     Ban.create(user_id: @administrator.id, valid_until: Date.tomorrow)
     longer_ban = Ban.create(user_id: @administrator.id, valid_until: Date.today + 6)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -34,7 +34,7 @@ class UserTest < ActiveSupport::TestCase
   def test_identity_code_can_be_empty_if_not_estonian
     user = User.new
 
-    user.surname = 'Surname'
+    user.surname = 'Surname ÄÖÜÕÜÖöäüüäö'
     user.given_names = 'Given Names'
     user.email = 'email@example.com'
     user.password = 'email@example.com'

--- a/test/system/admin/users/admin_users_list_test.rb
+++ b/test/system/admin/users/admin_users_list_test.rb
@@ -69,8 +69,8 @@ class AdminUsersListTest < ApplicationSystemTestCase
 
     expected_errors = ["Email can't be blank", "Password can't be blank",
                        "Mobile phone can't be blank", 'Terms and conditions must be accepted',
-                       'Mobile phone is invalid', "Given names can't be blank",
-                       "Surname can't be blank"]
+                       'Mobile phone is invalid', "Given names: can't be blank",
+                       "Surname: can't be blank"]
 
     assert_equal(errors_array.to_set, expected_errors.to_set)
   end

--- a/test/system/billing_profiles_test.rb
+++ b/test/system/billing_profiles_test.rb
@@ -64,8 +64,7 @@ class BillingProfilesTest < ApplicationSystemTestCase
     assert_no_changes('BillingProfile.count') do
       click_link_or_button('Submit')
     end
-
-    assert(page.has_text?('Vat code has already been taken'))
+    assert(page.has_text?('Vat code: has already been taken'))
   end
 
   def test_a_user_can_create_company_billing_profile_witout_vat_code


### PR DESCRIPTION
The main goal is not only sanitize user's input (rails strong params
are already done it), but to not save in DB user entered stuff
like '"><svg/onload=confirm(1)>' to save integrated systems

See #486

Merge after #491 