### PR TITLE
Remove wkhtmltopdf-binary gem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ cache:
     - node_modules
   yarn: true
 bundler_args: --without development staging production
+before_install:
+  - wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.xenial_amd64.deb
+  - sudo apt-get install -y gdebi
+  - sudo gdebi --non-interactive wkhtmltox_0.12.5-1.xenial_amd64.deb
 install:
   - bundle install
   - nvm install

--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,6 @@ gem 'simpleidn'
 gem 'sprockets', '~> 3.7'
 gem 'turbolinks', '~> 5'
 gem 'webpacker', '~> 4.0'
-gem 'wkhtmltopdf-binary'
 
 group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -312,7 +312,6 @@ GEM
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
-    wkhtmltopdf-binary (0.12.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.2.2)
@@ -354,7 +353,6 @@ DEPENDENCIES
   webdrivers
   webmock
   webpacker (~> 4.0)
-  wkhtmltopdf-binary
 
 BUNDLED WITH
    2.0.2


### PR DESCRIPTION
Removed wkhtmltopdf-binary from Gemfile as it's included now in docker image.

Modified Travis conf to include wkhtmltopdf binary in test env