### PR TITLE
Use PaymentOrder ID as VK_STAMP instead of array of invoice ids

### DIFF
--- a/app/models/payment_orders/estonian_bank_link.rb
+++ b/app/models/payment_orders/estonian_bank_link.rb
@@ -64,7 +64,7 @@ module PaymentOrders
       hash['VK_SERVICE']  = NEW_TRANSACTION_SERVICE_NUMBER
       hash['VK_VERSION']  = BANK_LINK_VERSION
       hash['VK_SND_ID']   = seller_account
-      hash['VK_STAMP']    = invoices.map(&:number).join(',')
+      hash['VK_STAMP']    = id.to_s
       hash['VK_AMOUNT'] = invoices_total.format(symbol: nil,
                                                 thousands_separator: false,
                                                 decimal_mark: '.')

--- a/test/models/payment_orders/payment_order_estonian_bank_link_test.rb
+++ b/test/models/payment_orders/payment_order_estonian_bank_link_test.rb
@@ -48,6 +48,7 @@ class PaymentOrderEstonianBankLinkTest < ActiveSupport::TestCase
     }.with_indifferent_access
 
     @orphaned_invoice.stub(:number, 1) do
+      @new_bank_link.id = 1
       form_fields = @new_bank_link.form_fields
 
       expected_fields.each do |k, v|
@@ -92,6 +93,7 @@ class PaymentOrderEstonianBankLinkTest < ActiveSupport::TestCase
     }.with_indifferent_access
 
     @orphaned_invoice.stub(:number, 1) do
+      @new_bank_link.id = 1
       form_fields = @new_bank_link.form_fields
 
       expected_fields.each do |k, v|


### PR DESCRIPTION
Closes #537 