### PR TITLE
Bank link: Truncate payment description if needed

### DIFF
--- a/app/controllers/payment_orders_controller.rb
+++ b/app/controllers/payment_orders_controller.rb
@@ -44,15 +44,9 @@ class PaymentOrdersController < ApplicationController
     ResultStatusUpdateJob.perform_later
 
     respond_to do |format|
-      invoice_ids = @payment_order.invoices.map(&:id).join(', ')
-      alert_text = if @payment_order.invoices.count > 1
-                     t('.bulk_update', ids: invoice_ids)
-                   else
-                     t(:updated)
-                   end
       if @payment_order.mark_invoice_as_paid
-        format.html { redirect_to invoices_path, notice: alert_text }
-        format.json { redirect_to invoices_path, notice: alert_text }
+        format.html { redirect_to invoices_path, notice: successful_update_notice }
+        format.json { redirect_to invoices_path, notice: successful_update_notice }
       else
         format.html do
           redirect_to invoices_path,
@@ -80,6 +74,13 @@ class PaymentOrdersController < ApplicationController
 
   def create_params
     params.require(:payment_order).permit(:user_id, :invoice_id, :invoice_ids, :type)
+  end
+
+  def successful_update_notice
+    invoice_ids = @payment_order.invoices.map(&:id).join(', ')
+    return t('.bulk_update', ids: invoice_ids) if @payment_order.invoices.count > 1
+
+    t(:updated)
   end
 
   def authorize_user

--- a/app/controllers/payment_orders_controller.rb
+++ b/app/controllers/payment_orders_controller.rb
@@ -77,7 +77,7 @@ class PaymentOrdersController < ApplicationController
   end
 
   def successful_update_notice
-    invoice_ids = @payment_order.invoices.map(&:id).join(', ')
+    invoice_ids = @payment_order.invoices.map(&:number).join(', ')
     return t('.bulk_update', ids: invoice_ids) if @payment_order.invoices.count > 1
 
     t(:updated)

--- a/app/models/payment_orders/estonian_bank_link.rb
+++ b/app/models/payment_orders/estonian_bank_link.rb
@@ -70,7 +70,7 @@ module PaymentOrders
                                                 decimal_mark: '.')
       hash['VK_CURR']     = Setting.find_by(code: 'auction_currency').retrieve
       hash['VK_REF']      = ''
-      hash['VK_MSG']      = invoices.map(&:title).join(',')
+      hash['VK_MSG']      = transaction_description
       hash['VK_RETURN']   = return_url
       hash['VK_CANCEL']   = return_url
       hash['VK_DATETIME'] = Time.zone.now.strftime('%Y-%m-%dT%H:%M:%S%z')
@@ -173,6 +173,13 @@ module PaymentOrders
 
     def invoices_total
       invoices.map(&:total).reduce(:+)
+    end
+
+    def transaction_description
+      description = invoices.map(&:title).join(',')
+      return description if description.length < 95
+
+      'Mass payment of auction center invoices'
     end
   end
 end

--- a/app/models/payment_orders/estonian_bank_link.rb
+++ b/app/models/payment_orders/estonian_bank_link.rb
@@ -179,7 +179,7 @@ module PaymentOrders
       description = invoices.map(&:title).join(',')
       return description if description.length < 95
 
-      'Mass payment of auction center invoices'
+      description.truncate(95, omission: '...')
     end
   end
 end

--- a/app/models/payment_orders/estonian_bank_link.rb
+++ b/app/models/payment_orders/estonian_bank_link.rb
@@ -70,7 +70,7 @@ module PaymentOrders
                                                 decimal_mark: '.')
       hash['VK_CURR']     = Setting.find_by(code: 'auction_currency').retrieve
       hash['VK_REF']      = ''
-      hash['VK_MSG']      = invoices.map(&:title).join(',').truncate(95, omission: '...')
+      hash['VK_MSG']      = invoices.map(&:title).join(',').truncate(94, omission: '...')
       hash['VK_RETURN']   = return_url
       hash['VK_CANCEL']   = return_url
       hash['VK_DATETIME'] = Time.zone.now.strftime('%Y-%m-%dT%H:%M:%S%z')

--- a/app/models/payment_orders/estonian_bank_link.rb
+++ b/app/models/payment_orders/estonian_bank_link.rb
@@ -70,7 +70,7 @@ module PaymentOrders
                                                 decimal_mark: '.')
       hash['VK_CURR']     = Setting.find_by(code: 'auction_currency').retrieve
       hash['VK_REF']      = ''
-      hash['VK_MSG']      = transaction_description
+      hash['VK_MSG']      = invoices.map(&:title).join(',').truncate(95, omission: '...')
       hash['VK_RETURN']   = return_url
       hash['VK_CANCEL']   = return_url
       hash['VK_DATETIME'] = Time.zone.now.strftime('%Y-%m-%dT%H:%M:%S%z')
@@ -173,13 +173,6 @@ module PaymentOrders
 
     def invoices_total
       invoices.map(&:total).reduce(:+)
-    end
-
-    def transaction_description
-      description = invoices.map(&:title).join(',')
-      return description if description.length < 95
-
-      description.truncate(95, omission: '...')
     end
   end
 end

--- a/config/locales/payment_orders.en.yml
+++ b/config/locales/payment_orders.en.yml
@@ -15,3 +15,4 @@ en:
     return:
       not_successful: "Payment failed, please make sure there are enough funds on the account and try again. If the problem persists please contact us by email info@internet.ee or call to +372 727 1000"
       already_paid: "This invoice has already been paid."
+      bulk_update: "Payment successful! Following invoices were marked as paid:  %{ids}"

--- a/config/locales/payment_orders.en.yml
+++ b/config/locales/payment_orders.en.yml
@@ -15,4 +15,4 @@ en:
     return:
       not_successful: "Payment failed, please make sure there are enough funds on the account and try again. If the problem persists please contact us by email info@internet.ee or call to +372 727 1000"
       already_paid: "This invoice has already been paid."
-      bulk_update: "Payment successful! Following invoices were marked as paid:  %{ids}"
+      bulk_update: "Payment successful! Following invoices were marked as paid: %{ids}"

--- a/config/locales/payment_orders.et.yml
+++ b/config/locales/payment_orders.et.yml
@@ -15,3 +15,4 @@ et:
     return:
       not_successful: "Makse ebaõnnestus. Veenduge, et kontol on piisavalt raha ning proovige uuesti. Kui probleem on pidev, siis võtke meiega ühendust aadressil info@internet.ee või helistage +372 727 1000"
       already_paid: "Arve on juba makstud."
+      bulk_update: "Aitäh eduka makse eest! Märgitud makstuks järgnevad arved: %{ids}"

--- a/test/models/payment_orders/payment_order_estonian_bank_link_test.rb
+++ b/test/models/payment_orders/payment_order_estonian_bank_link_test.rb
@@ -126,10 +126,10 @@ class PaymentOrderEstonianBankLinkTest < ActiveSupport::TestCase
   end
 
   def test_too_long_payment_description_gets_truncated
-    long_string = 'This is way longer than 95 characters This is way longer than 95 characters This is way longer than 95 characters This is way longer than 95 characters'
+    long_string = 'This is way longer than 94 characters This is way longer than 94 characters This is way longer than 94 characters This is way longer than 94 characters'
 
     @orphaned_invoice.stub(:title, long_string) do
-      assert_equal 95, @new_bank_link.form_fields['VK_MSG'].length
+      assert_equal 94, @new_bank_link.form_fields['VK_MSG'].length
     end
   end
 

--- a/test/models/payment_orders/payment_order_estonian_bank_link_test.rb
+++ b/test/models/payment_orders/payment_order_estonian_bank_link_test.rb
@@ -125,6 +125,14 @@ class PaymentOrderEstonianBankLinkTest < ActiveSupport::TestCase
     assert_equal('lhv', PaymentOrders::LHV.config_namespace_name)
   end
 
+  def test_too_long_payment_description_gets_truncated
+    long_string = 'This is way longer than 95 characters This is way longer than 95 characters This is way longer than 95 characters This is way longer than 95 characters'
+
+    @orphaned_invoice.stub(:title, long_string) do
+      assert_equal 95, @new_bank_link.form_fields['VK_MSG'].length
+    end
+  end
+
   def create_cancelled_bank_link
     params = {
       'VK_SERVICE': '1911',


### PR DESCRIPTION
Closes #546

Truncates the description to 95 characters in case it's longer. Shows list of Invoice IDs to user via notification after successful payment.