### PR TITLE
Remove linkpay links if no linkpay data set

### DIFF
--- a/app/models/concerns/invoice/linkpayable.rb
+++ b/app/models/concerns/invoice/linkpayable.rb
@@ -24,6 +24,7 @@ module Concerns
                                                      CONFIG_NAMESPACE.to_sym, :linkpay_token)
 
       def linkpay_url
+        return unless linkpay_prefix
         return unless PaymentOrder.supported_methods.include?('PaymentOrders::EveryPay'.constantize)
         return if paid?
 
@@ -35,7 +36,11 @@ module Concerns
         data = linkpay_params(price).to_query
 
         hmac = OpenSSL::HMAC.hexdigest('sha256', KEY, data)
-        "#{LINKPAY_PREFIX}?#{data}&hmac=#{hmac}"
+        "#{linkpay_prefix}?#{data}&hmac=#{hmac}"
+      end
+
+      def linkpay_prefix
+        Rails.env.test? ? ENV['linkpay_prefix'] : LINKPAY_PREFIX
       end
 
       def linkpay_params(price)

--- a/test/models/invoice_test.rb
+++ b/test/models/invoice_test.rb
@@ -181,11 +181,18 @@ class InvoiceTest < ActiveSupport::TestCase
   def test_linkpay_url
     total = invoices_total([@payable_invoice]).to_s
     linkpay_token = PaymentOrders::EveryPay::LINKPAY_TOKEN
+    ENV['linkpay_prefix'] = 'some_prefix'
     url = @payable_invoice.linkpay_url
 
     assert(url.include? total)
     assert(url.include? linkpay_token)
     assert(url.include? @payable_invoice.id.to_s)
+  end
+
+  def test_linkpay_url_nil_if_no_linkpay
+    ENV['linkpay_prefix'] = nil
+
+    assert_nil @payable_invoice.linkpay_url
   end
 
   def test_linkpay_url_nil_if_paid


### PR DESCRIPTION
This PR removes linkpay links from emails if no linkpay urls configured in the system.