### PR TITLE
changed logic for ends_at and initial_ends_at

### DIFF
--- a/app/models/registry/auction_creator.rb
+++ b/app/models/registry/auction_creator.rb
@@ -85,14 +85,23 @@ module Registry
         auction.ends_at = nil
       else
         legacy_auction = auctions.first
-        new_ends_at = legacy_auction.ends_at
-        if legacy_auction.initial_ends_at.present?
-          legacy_time_difference = (legacy_auction.initial_ends_at - legacy_auction.starts_at).to_i.abs
-          legacy_difference_in_day = legacy_time_difference / 86_400
-          legacy_time = legacy_auction.initial_ends_at.strftime('%H:%M:%S')
-          t = Time.parse(legacy_time).seconds_since_midnight.seconds
-          new_ends_at = Time.zone.now.beginning_of_day + legacy_difference_in_day.day + t
-        end
+        # new_ends_at = legacy_auction.ends_at
+        # if legacy_auction.initial_ends_at.present?
+        #   legacy_time_difference = (legacy_auction.initial_ends_at - legacy_auction.starts_at).to_i.abs
+        #   legacy_difference_in_day = legacy_time_difference / 86_400
+        #   legacy_time = legacy_auction.initial_ends_at.strftime('%H:%M:%S')
+        #   t = Time.parse(legacy_time).seconds_since_midnight.seconds
+        #   new_ends_at = Time.zone.now.beginning_of_day + legacy_difference_in_day.day + t
+        # end
+
+        
+        ends_at_value = legacy_auction.initial_ends_at.present? ? legacy_auction.initial_ends_at : legacy_auction.ends_at
+
+        legacy_time_difference = (ends_at_value- legacy_auction.starts_at).to_i.abs
+        legacy_difference_in_day = legacy_time_difference / 86_400
+        legacy_time = ends_at_value.strftime('%H:%M:%S')
+        t = Time.parse(legacy_time).seconds_since_midnight.seconds
+        new_ends_at = Time.zone.now.beginning_of_day + legacy_difference_in_day.day + t
 
         auction.starting_price = legacy_auction.starting_price
         auction.min_bids_step = legacy_auction.starting_price


### PR DESCRIPTION
Close #1030 

I was unable to reproduce the error on the staging, but in this branch I have changed the logic of the `ends_at` assignment a bit. The point is that such an error could theoretically occur to auctions, which `initial_ends_at` field is not initialized, and auctions missed rounds for some reason or there was some delay. Therefore, before merging this branch, we need to test the entire logic of adding new domains to the auction and also test the addition of domains in the next rounds!