### PR TITLE
rake task for change registration deadline

### DIFF
--- a/lib/tasks/settings_change.rake
+++ b/lib/tasks/settings_change.rake
@@ -1,0 +1,9 @@
+namespace :settings do
+  desc ''
+
+  # rake settings:deadline_registration[30]
+  task :deadline_registration, [:value] => [:environment] do |_t, args|
+    registration_deadline = Setting.find_by_code(:registration_term)
+    registration_deadline.update!(value: args[:value].to_s)
+  end
+end


### PR DESCRIPTION
close #1047 

Task for run:
`rake settings:deadline_registration[number]` where instead of `number` should be integer. In our case `30`. so final command looks like this `rake settings:deadline_registration[30]`