### PR TITLE
hot fix: restriction for redirect

### DIFF
--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -56,7 +56,7 @@ class InvoicesController < ApplicationController
                                                     customer_url: linkpay_callback_url)
 
     if response.result?
-      redirect_to response.instance['oneoff_redirect_link']
+      redirect_to response.instance['oneoff_redirect_link'], allow_other_host: true
     else
       flash.alert = response.errors
       redirect_to invoices_path and return


### PR DESCRIPTION
**Problem:**

- An error occurs when attempting to pay all invoices

**Reason:**

- The system blocks going to external resources

**Solution**

- Add allow_other_host: true on redirects

**How to test?**

- Try to pay all bills
