### PR TITLE
get rid validation from payment order types

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,13 +69,13 @@ RUN apt-get install -y --no-install-recommends > /dev/null \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-RUN curl https://chromedriver.storage.googleapis.com/2.46/chromedriver_linux64.zip -o /chromedriver_linux64.zip
-RUN apt-get update > /dev/null \
-    && apt-get install -yf --no-install-recommends > /dev/null unzip=* \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-RUN unzip chromedriver_linux64.zip -d /usr/local/bin
-RUN rm /chromedriver_linux64.zip
+# RUN curl https://chromedriver.storage.googleapis.com/2.46/chromedriver_linux64.zip -o /chromedriver_linux64.zip
+# RUN apt-get update > /dev/null \
+#     && apt-get install -yf --no-install-recommends > /dev/null unzip=* \
+#     && apt-get clean \
+#     && rm -rf /var/lib/apt/lists/*
+# RUN unzip chromedriver_linux64.zip -d /usr/local/bin
+# RUN rm /chromedriver_linux64.zip
 
 # RUN npm install --global yarn
 RUN npm install -g yarn@latest

--- a/app/models/payment_order.rb
+++ b/app/models/payment_order.rb
@@ -1,14 +1,14 @@
 class PaymentOrder < ApplicationRecord
-  ENABLED_METHODS = AuctionCenter::Application.config
-                                              .customization
-                                              .dig(:payment_methods, :enabled_methods)
+  # ENABLED_METHODS = AuctionCenter::Application.config
+  #                                             .customization
+  #                                             .dig(:payment_methods, :enabled_methods)
 
   enum status: { issued: 'issued',
                  paid: 'paid',
                  cancelled: 'cancelled' }
 
   validates :user_id, presence: true, on: :create
-  validates :type, inclusion: { in: ENABLED_METHODS }
+  # validates :type, inclusion: { in: ENABLED_METHODS }
 
   validate :invoice_cannot_be_already_paid, on: :create
 
@@ -34,15 +34,15 @@ class PaymentOrder < ApplicationRecord
     errors.add(:invoice, 'is already paid')
   end
 
-  def self.supported_method?(some_class)
-    raise(Errors::ExpectedPaymentOrder, some_class) unless some_class < PaymentOrder
+  # def self.supported_method?(some_class)
+  #   raise(Errors::ExpectedPaymentOrder, some_class) unless some_class < PaymentOrder
 
-    if ENABLED_METHODS.include?(some_class.name)
-      true
-    else
-      false
-    end
-  end
+  #   if ENABLED_METHODS.include?(some_class.name)
+  #     true
+  #   else
+  #     false
+  #   end
+  # end
 
   def self.with_cache
     Rails.cache.fetch("#{new.cache_key}/#{config_namespace_name}_icon",

--- a/app/models/payment_order.rb
+++ b/app/models/payment_order.rb
@@ -1,15 +1,9 @@
 class PaymentOrder < ApplicationRecord
-  # ENABLED_METHODS = AuctionCenter::Application.config
-  #                                             .customization
-  #                                             .dig(:payment_methods, :enabled_methods)
-
   enum status: { issued: 'issued',
                  paid: 'paid',
                  cancelled: 'cancelled' }
 
   validates :user_id, presence: true, on: :create
-  # validates :type, inclusion: { in: ENABLED_METHODS }
-
   validate :invoice_cannot_be_already_paid, on: :create
 
   has_many :invoice_payment_orders, dependent: :destroy
@@ -34,16 +28,6 @@ class PaymentOrder < ApplicationRecord
     errors.add(:invoice, 'is already paid')
   end
 
-  # def self.supported_method?(some_class)
-  #   raise(Errors::ExpectedPaymentOrder, some_class) unless some_class < PaymentOrder
-
-  #   if ENABLED_METHODS.include?(some_class.name)
-  #     true
-  #   else
-  #     false
-  #   end
-  # end
-
   def self.with_cache
     Rails.cache.fetch("#{new.cache_key}/#{config_namespace_name}_icon",
                       expires_in: 12.hours) do
@@ -54,17 +38,4 @@ class PaymentOrder < ApplicationRecord
   def channel
     type.gsub('PaymentOrders::', '')
   end
-
-  # def self.supported_methods
-  #   enabled = []
-
-  #   ENABLED_METHODS.each do |method|
-  #     class_name = method.constantize
-  #     raise(Errors::ExpectedPaymentOrder, class_name) unless class_name < PaymentOrder
-
-  #     enabled << class_name
-  #   end
-
-  #   enabled
-  # end
 end

--- a/config/customization.yml.sample
+++ b/config/customization.yml.sample
@@ -74,9 +74,6 @@ default: &default
     tracking_id:
 
   payment_methods:
-    enabled_methods:
-      - "PaymentOrders::EveryPay"
-
     every_pay:
       url: ''
       user: ''
@@ -86,13 +83,6 @@ default: &default
       linkpay_prefix: 'https://igw-demo.every-pay.com/lp'
       linkpay_check_prefix: 'https://igw-demo.every-pay.com/api/v3/payments/'
       linkpay_token: 'rucd4v'
-
-    seb:
-      url: ''
-      seller_account: ''
-      seller_private_key: ''
-      bank_certificate: ''
-      icon: '/images/payment_methods/seb.png'
 
   messente:
     username: 'messente_user'
@@ -137,10 +127,6 @@ test:
   <<: *default
 
   payment_methods:
-    enabled_methods:
-      - "PaymentOrders::EveryPay"
-      - "PaymentOrders::SEB"
-
     every_pay:
       url: 'https://igw-demo.every-pay.com/transactions/'
       user: 'api_user'
@@ -150,13 +136,6 @@ test:
       linkpay_prefix: 'https://igw-demo.every-pay.com/lp'
       linkpay_check_prefix: 'https://igw-demo.every-pay.com/api/v3/payments/'
       linkpay_token: 'rucd4v'
-
-    seb:
-      url: 'https://www.seb.ee/cgi-bin/dv.sh/ipank.r'
-      seller_account: 'testvpos'
-      seller_private_key: 'test/fixtures/files/seb_seller_key.pem'
-      bank_certificate: 'test/fixtures/files/seb_bank_cert.pem'
-      icon: '/images/payment_methods/seb.png'
 
   messente:
     username: 'messente_user'

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -7,6 +7,9 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
 
   include SemanticUiHelper
 
+  # 115.0.5790
+  Webdrivers::Chromedriver.required_version = '114.0.5735.90'
+
   Capybara.register_driver(:headless_chrome) do |app|
     options = ::Selenium::WebDriver::Chrome::Options.new
     options.add_argument('--headless')

--- a/test/models/payment_order_test.rb
+++ b/test/models/payment_order_test.rb
@@ -24,26 +24,26 @@ class PaymentOrderTest < ActiveSupport::TestCase
     assert_equal(PaymentOrder.statuses[:issued], payment_order.status)
   end
 
-  def test_allowed_types_are_taken_from_config
-    assert(PaymentOrder::ENABLED_METHODS.include? 'PaymentOrders::EveryPay')
-  end
+  # def test_allowed_types_are_taken_from_config
+  #   assert(PaymentOrder::ENABLED_METHODS.include? 'PaymentOrders::EveryPay')
+  # end
 
-  def test_supported_method_returns_true_or_false
-    assert(PaymentOrder.supported_method?(PaymentOrders::EveryPay))
-  end
+  # def test_supported_method_returns_true_or_false
+  #   assert(PaymentOrder.supported_method?(PaymentOrders::EveryPay))
+  # end
 
-  def test_payment_method_must_be_supported_for_the_object_to_be_valid
-    payment_order = PaymentOrder.new
+  # def test_payment_method_must_be_supported_for_the_object_to_be_valid
+  #   payment_order = PaymentOrder.new
 
-    payment_order.invoices << @payable_invoice
-    payment_order.user = @user
-    payment_order.type = 'PaymentOrders::EveryPay'
+  #   payment_order.invoices << @payable_invoice
+  #   payment_order.user = @user
+  #   payment_order.type = 'PaymentOrders::EveryPay'
 
-    assert(payment_order.valid?)
+  #   assert(payment_order.valid?)
 
-    payment_order.type = 'PaymentOrders::Manual'
-    assert_not(payment_order.valid?)
-  end
+  #   payment_order.type = 'PaymentOrders::Manual'
+  #   assert_not(payment_order.valid?)
+  # end
 
   def test_invoice_cannot_be_already_paid
     payment_order = PaymentOrder.new


### PR DESCRIPTION
**What was the reason for refactoring?**
The validation of some data depends on the values specified in customization.yml. This was done back in the days when there was no integration with Everypay, and different payment nodes such as Swedbank, Seb, Lhv, etc., were used. However, they are no longer used and are not relevant because we only use Everypay, and therefore the validation is no longer relevant. Whatever the payment, it will still have the Everypay type in the STI mechanism. And any change in `customization.yml` settings can crash the application since we have old payment records stored.

**What did I do?**
I removed the code responsible for validation in payment order. I also removed the code from the `customization.yml` settings that is no longer relevant. These are the following keys:
The entire block found in `enabled_methods`:
```
    enabled_methods:
      - "PaymentOrders::EveryPay"
```

And also removed the unnecessary `seb` block (if it still exists in the production configuration file):
```
seb:
      url: ''
      seller_account: ''
      seller_private_key: ''
      bank_certificate: ''
      icon: '/images/payment_methods/seb.png'
```

**How to test/review?**
I've already looked in the staging environment, and I haven't encountered any problems there yet. However, it is essential to double-check in the test environment, which is very close to production. The fact is, in production, we store those old records, which have a SEB type and due to which an error occurred some time ago. Therefore, it's necessary to test the application, create accounts, make payments, and ensure that there are no error messages in the logs.

**What will you do next?**
We have old records where the payment type is not Everypay but, for example, the old SEB type, which is no longer relevant in our business logic. I see four scenarios:
-     delete all records with old entries (bad option)
-     update old records and assign them the Everyapy type (not the best option either)
-     come up with a new type, for example, Deprecated, and assign all old records this type (compromise option)
-     leave the records as they are (simple option).