### PR TITLE
added localize parameters to url

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,7 @@ group :test do
   gem 'capybara', '>= 2.15'
   gem 'simplecov', '~> 0.10', '< 0.18', require: false
   gem 'spy'
-  gem 'webdrivers'
+  gem 'selenium-webdriver'
   gem 'webmock'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -408,10 +408,6 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     webfinger (1.2.0)
       activesupport
       httpclient (>= 2.4)
@@ -479,6 +475,7 @@ DEPENDENCIES
   rubocop-performance
   ruby-openai
   scenic
+  selenium-webdriver
   simplecov (~> 0.10, < 0.18)
   simpleidn
   skylight
@@ -486,7 +483,6 @@ DEPENDENCIES
   spy
   turbo-rails
   web-console (>= 3.3.0)
-  webdrivers
   webmock
   webpacker (~> 6.0.0.rc.5)
   webpush

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,12 +8,16 @@ class ApplicationController < ActionController::Base
     policy.style_src :self, 'www.gstatic.com', :unsafe_inline
   end
 
-  rescue_from CanCan::AccessDenied do |exception|
+  rescue_from CanCan::AccessDenied do |_exception|
     flash[:alert] = I18n.t('unauthorized.message')
     redirect_to root_url
   end
 
   def set_locale
+    if params[:localize].present? && I18n.available_locales.include?(params[:localize].to_sym)
+      cookies[:locale] = params[:localize]
+    end
+
     I18n.locale = current_user&.locale || cookies[:locale] || I18n.default_locale
     @pagy_locale = I18n.locale.to_s
   end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -7,9 +7,6 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
 
   include SemanticUiHelper
 
-  # 115.0.5790
-  Webdrivers::Chromedriver.required_version = '114.0.5735.90'
-
   Capybara.register_driver(:headless_chrome) do |app|
     options = ::Selenium::WebDriver::Chrome::Options.new
     options.add_argument('--headless')
@@ -19,8 +16,6 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
 
     Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
   end
-
-  Webdrivers::Chromedriver.required_version = '114.0.5735.90'
 
   driven_by :headless_chrome
   Capybara.server = :puma, { Silent: true }


### PR DESCRIPTION
**What's the problem?**
In the current functionality of the auction, there's no direct link to the localized part of the service. To change localization, a link with a PATCH action is used, which either assigns the user's localization value in the database or sets it in the cookies. However, due to the need for marketing purposes to have a direct link to localization, a solution needs to be found.

**How did you solve it?**
It's very simple, I added a callback in the controller that tracks the "localize" parameter in the URL. Based on this parameter, the user's localization is set in their cookies. The direct link to localization looks like this:
**https://auction.test/?localize=en**

**How do we verify that you didn't break anything?**
You need to make sure that this functionality does not break the main localization features. The auction should still open for users with the localization that they have set. Websockets should also come with the correct localization.

**Is there anything else we should know?**
Yes, this feature does not work with browsers in incognito mode, as there are no cookies there.