### PR TITLE
sort fixing

### DIFF
--- a/app/controllers/admin/invoices_controller.rb
+++ b/app/controllers/admin/invoices_controller.rb
@@ -15,21 +15,9 @@ module Admin
 
     # GET /admin/invoices
     def index
-      sort_column = params[:sort].presence_in(%w[paid_through
-                                                 paid_amount
-                                                 vat_rate
-                                                 cents
-                                                 notes
-                                                 status
-                                                 number
-                                                 due_date
-                                                 billing_profile_id]) || 'id'
-      sort_direction = params[:direction].presence_in(%w[asc desc]) || 'desc'
-
       invoices = Invoice.accessible_by(current_ability)
                         .includes(:paid_with_payment_order)
                         .search(params)
-                        .order("#{sort_column} #{sort_direction}")
 
       @pagy, @invoices = pagy(invoices, items: params[:per_page] ||= 15)
     end

--- a/app/controllers/admin/invoices_controller.rb
+++ b/app/controllers/admin/invoices_controller.rb
@@ -1,4 +1,4 @@
-# rubocop:disable Metrics/ClassLength
+# rubocop:disable Metrics
 # require 'invoice_already_paid'
 
 module Admin
@@ -19,7 +19,12 @@ module Admin
                         .includes(:paid_with_payment_order)
                         .search(params)
 
-      @pagy, @invoices = pagy(invoices, items: params[:per_page] ||= 15)
+      if invoices.is_a?(Array)
+        @pagy, @invoices = pagy_array(invoices, items: params[:per_page] ||= 15)
+      else
+        @pagy, @invoices = pagy(invoices, items: params[:per_page] ||= 15)
+      end
+
     end
 
     # GET /admin/invoices/aa450f1a-45e2-4f22-b2c3-f5f46b5f906b/download

--- a/app/controllers/auctions_controller.rb
+++ b/app/controllers/auctions_controller.rb
@@ -30,9 +30,9 @@ class AuctionsController < ApplicationController
 
   def fetch_auctions_list
     if should_sort_auctions?
-      Auction.active.ai_score_order.search(params).with_user_offers(current_user&.id)
+      Auction.active.ai_score_order.search(params, current_user).with_user_offers(current_user&.id)
     else
-      Auction.active.search(params).with_user_offers(current_user&.id)
+      Auction.active.search(params, current_user).with_user_offers(current_user&.id)
     end
   end
 

--- a/app/controllers/histories_controller.rb
+++ b/app/controllers/histories_controller.rb
@@ -3,7 +3,6 @@ class HistoriesController < ApplicationController
 
   def index
     auctions = Auction.where('ends_at <= ?', Time.zone.now)
-                      .order(ends_at: :desc, domain_name: :asc)
                       .search(params)
 
     @pagy, @auctions = pagy(auctions, items: params[:per_page] ||= 20,

--- a/app/models/auction.rb
+++ b/app/models/auction.rb
@@ -1,8 +1,11 @@
+# rubocop:disable Metrics
 class Auction < ApplicationRecord
   include Presentable
+  include Searchable
   include PgSearch::Model
 
   BLIND = '0'.freeze
+  ENGLISH = '1'.freeze
 
   after_create :find_auction_turns
   validates :domain_name, presence: true
@@ -25,65 +28,6 @@ class Auction < ApplicationRecord
   after_update_commit :update_list_broadcast, unless: :skip_broadcast
   after_update_commit :update_offer_broadcast, unless: :skip_broadcast
 
-  scope :active, -> { where('starts_at <= ? AND ends_at >= ?', Time.now.utc, Time.now.utc) }
-  scope :without_result, lambda {
-    where('ends_at < ? and id NOT IN (SELECT results.auction_id FROM results)', Time.now.utc)
-  }
-
-  scope :for_period, lambda { |start_date, end_date|
-    where(ends_at: start_date.beginning_of_day..end_date.end_of_day)
-  }
-
-  scope :random_order, -> { order(Arel.sql('RANDOM()')) }
-  scope :ai_score_order, lambda {
-    order(Arel.sql('CASE WHEN ai_score > 0 THEN ai_score ELSE RANDOM() END DESC'))
-  }
-
-  scope :without_offers, -> { includes(:offers).where(offers: { auction_id: nil }) }
-  scope :with_offers, -> { includes(:offers).where.not(offers: { auction_id: nil }) }
-  scope :with_domain_name, (lambda do |domain_name|
-    return unless domain_name.present?
-
-    where('domain_name like ?', "%#{domain_name}%")
-  end)
-
-  scope :with_type, (lambda do |type|
-    if type.present?
-      return where(platform: [type, nil]) if type == BLIND
-
-      where(platform: type)
-    end
-  end)
-
-  def self.with_max_offer_cents
-    joins("LEFT JOIN (SELECT auction_id, MAX(cents) AS max_offer_cents FROM offers GROUP BY auction_id) AS offers_subquery ON auctions.id = offers_subquery.auction_id")
-  end  
-
-  scope :with_starts_at, (lambda do |starts_at|
-    where('starts_at >= ?', starts_at.to_date.beginning_of_day) if starts_at.present?
-  end)
-
-  scope :with_ends_at, (lambda do |ends_at|
-    where('ends_at <= ?', ends_at.to_date.end_of_day) if ends_at.present?
-  end)
-  scope :with_starts_at_nil, ->(state) { where(starts_at: nil) if state.present? }
-
-  scope :english, -> { where(platform: :english) }
-  scope :not_english, -> { where.not(platform: :english) }
-
-  scope :with_offers, (lambda do |auction_offer_type, type|
-    return if auction_offer_type.blank? || type == BLIND || type.empty?
-
-    case auction_offer_type
-    when 'with_offers'
-      auction_id_list = self.select { |a| a.offers.present? }.pluck(:id)
-    when 'without_offers'
-      auction_id_list = self.select { |a| a.offers.empty? }.pluck(:id)
-    end
-
-    where(id: auction_id_list)
-  end)
-
   delegate :count, to: :offers, prefix: true
   delegate :size, to: :offers, prefix: true
 
@@ -104,38 +48,6 @@ class Auction < ApplicationRecord
     deposit = Money.from_amount(number, Setting.find_by(code: 'auction_currency').retrieve)
     self.requirement_deposit_in_cents = deposit.cents
   end
-
-  def self.search(params = {})
-    param_list = %w[domain_name starts_at ends_at platform users_price]
-    sort_column = params[:sort].presence_in(param_list) || 'domain_name'
-    sort_admin_column = params[:sort].presence_in(%w[domain name
-                                                     starts_at
-                                                     ends_at
-                                                     highest_offer_cents
-                                                     number_of_offers
-                                                     turns_count
-                                                     starting_price
-                                                     min_bids_step
-                                                     slipping_end
-                                                     platform]) || 'id'
-    sort_direction = params[:direction].presence_in(%w[asc desc]) || 'desc'
-    is_from_admin = params[:admin] == 'true'
-
-    query = self
-      .with_highest_offers
-      .with_domain_name(params[:domain_name])
-      .with_type(params[:type])
-      .with_starts_at(params[:starts_at])
-      .with_ends_at(params[:ends_at])
-      .with_starts_at_nil(params[:starts_at_nil])
-      .with_offers(params[:auction_offer_type], params[:type])
-
-    if params[:sort] == "users_price"
-      query.with_max_offer_cents.order("offers_subquery.max_offer_cents #{sort_direction} NULLS LAST")
-    else
-      query.order("#{is_from_admin ? sort_admin_column : sort_column} #{sort_direction} NULLS LAST")
-    end
-end
 
   def deposit_and_enable_deposit_should_be_togeter
     return unless english?

--- a/app/models/auction/searchable.rb
+++ b/app/models/auction/searchable.rb
@@ -1,0 +1,143 @@
+# rubocop:disable Metrics
+module Auction::Searchable
+  extend ActiveSupport::Concern
+
+  included do
+    scope :active, -> { where('starts_at <= ? AND ends_at >= ?', Time.now.utc, Time.now.utc) }
+    scope :without_result, lambda {
+      where('ends_at < ? and id NOT IN (SELECT results.auction_id FROM results)', Time.now.utc)
+    }
+
+    scope :for_period, lambda { |start_date, end_date|
+      where(ends_at: start_date.beginning_of_day..end_date.end_of_day)
+    }
+
+    scope :random_order, -> { order(Arel.sql('RANDOM()')) }
+    scope :ai_score_order, lambda {
+      order(Arel.sql('CASE WHEN ai_score > 0 THEN ai_score ELSE RANDOM() END DESC'))
+    }
+
+    scope :without_offers, -> { includes(:offers).where(offers: { auction_id: nil }) }
+    scope :with_offers, -> { includes(:offers).where.not(offers: { auction_id: nil }) }
+    scope :with_domain_name, (lambda do |domain_name|
+      return unless domain_name.present?
+
+      where('domain_name like ?', "%#{domain_name}%")
+    end)
+
+    scope :with_type, (lambda do |type|
+      if type.present?
+        return where(platform: [type, nil]) if type == BLIND
+
+        where(platform: type)
+      end
+    end)
+
+    scope :with_starts_at, (lambda do |starts_at|
+      where('starts_at >= ?', starts_at.to_date.beginning_of_day) if starts_at.present?
+    end)
+
+    scope :with_ends_at, (lambda do |ends_at|
+      where('ends_at <= ?', ends_at.to_date.end_of_day) if ends_at.present?
+    end)
+    scope :with_starts_at_nil, ->(state) { where(starts_at: nil) if state.present? }
+
+    scope :english, -> { where(platform: :english) }
+    scope :not_english, -> { where.not(platform: :english) }
+
+    scope :with_offers, (lambda do |auction_offer_type, type|
+      return if auction_offer_type.blank? || type == BLIND || type.empty?
+
+      case auction_offer_type
+      when 'with_offers'
+        auction_id_list = self.select { |a| a.offers.present? }.pluck(:id)
+      when 'without_offers'
+        auction_id_list = self.select { |a| a.offers.empty? }.pluck(:id)
+      end
+
+      where(id: auction_id_list)
+    end)
+  end
+
+  class_methods do
+    def search(params = {}, current_user = nil)
+      param_list = %w[domain_name starts_at ends_at platform users_price]
+      sort_column = params[:sort].presence_in(param_list) || 'domain_name'
+      sort_admin_column = params[:sort].presence_in(%w[domain_name
+                                                       starts_at
+                                                       ends_at
+                                                       highest_offer_cents
+                                                       number_of_offers
+                                                       turns_count
+                                                       starting_price
+                                                       min_bids_step
+                                                       slipping_end
+                                                       platform
+                                                       requirement_deposit_in_cents
+                                                       enable_deposit]) || 'id'
+      sort_direction = params[:direction].presence_in(%w[asc desc]) || 'desc'
+      is_from_admin = params[:admin] == 'true'
+
+      query =
+        with_highest_offers
+        .with_domain_name(params[:domain_name])
+        .with_type(params[:type])
+        .with_starts_at(params[:starts_at])
+        .with_ends_at(params[:ends_at])
+        .with_starts_at_nil(params[:starts_at_nil])
+        .with_offers(params[:auction_offer_type], params[:type])
+
+      if params[:sort] == 'users_price'
+        query.with_max_offer_cents_for_english_auction(current_user).order("offers_subquery.max_offer_cents #{sort_direction} NULLS LAST")
+      elsif params[:sort] == 'username'
+        query.sorted_by_winning_offer_username.order("offers_subquery.username #{sort_direction} NULLS LAST")
+      else
+        query.order("#{is_from_admin ? sort_admin_column : sort_column} #{sort_direction} NULLS LAST")
+      end
+    end
+
+    def with_max_offer_cents_for_english_auction(user = nil)
+      if user
+        joins(<<-SQL
+          LEFT JOIN (
+            SELECT auction_id, MAX(cents) AS max_offer_cents
+            FROM offers
+            WHERE auction_id IN (
+              SELECT id FROM auctions WHERE platform = 1
+              UNION
+              SELECT auction_id FROM offers WHERE user_id = #{user.id} AND auction_id IN (SELECT id FROM auctions WHERE platform IS NULL OR platform = 0)
+            )
+            GROUP BY auction_id
+          ) AS offers_subquery ON auctions.id = offers_subquery.auction_id
+        SQL
+             )
+      else
+        joins(<<-SQL
+          LEFT JOIN (
+            SELECT auction_id, MAX(cents) AS max_offer_cents
+            FROM offers
+            WHERE auction_id IN (SELECT id FROM auctions WHERE platform = 1)
+            GROUP BY auction_id
+          ) AS offers_subquery ON auctions.id = offers_subquery.auction_id
+        SQL
+             )
+      end
+    end
+
+    def sorted_by_winning_offer_username
+      joins(<<-SQL
+        LEFT JOIN (
+          SELECT offers.auction_id, offers.username
+          FROM offers
+          WHERE offers.cents = (
+            SELECT MAX(offers_inner.cents)
+            FROM offers AS offers_inner
+            WHERE offers_inner.auction_id = offers.auction_id
+          )
+          GROUP BY offers.auction_id, offers.username
+        ) AS offers_subquery ON auctions.id = offers_subquery.auction_id
+      SQL
+           )
+    end
+  end
+end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -70,7 +70,7 @@ class Invoice < ApplicationRecord
                                                status
                                                number
                                                due_date
-                                               billing_profile_id]) || 'id'
+                                               billing_profile_name]) || 'id'
     sort_direction = params[:direction].presence_in(%w[asc desc]) || 'desc'
 
     query = with_search_scope(params[:search_string]).with_statuses(params[:statuses_contains])
@@ -78,9 +78,11 @@ class Invoice < ApplicationRecord
     if params[:sort] == 'channel'
       query.left_outer_joins(:payment_orders)
            .select("invoices.*, REPLACE(payment_orders.type, 'PaymentOrders::', '') AS payment_order_channel")
-           .order(Arel.sql("payment_order_channel #{sort_direction}"))
+           .order(Arel.sql("payment_order_channel #{sort_direction} NULLS LAST"))
+    elsif params[:sort] == 'billing_profile_name'
+      query.left_outer_joins(:billing_profile).order("billing_profiles.name #{sort_direction} NULLS LAST")
     else
-      query.order("#{sort_column} #{sort_direction}")
+      query.order("#{sort_column} #{sort_direction} NULLS LAST")
     end
   end
 

--- a/app/models/payment_orders/lhv.rb
+++ b/app/models/payment_orders/lhv.rb
@@ -1,5 +1,5 @@
 module PaymentOrders
-  class Lhv < EstonianBankLink
+  class LHV < EstonianBankLink
     def self.config_namespace_name
       'lhv'
     end

--- a/app/models/payment_orders/seb.rb
+++ b/app/models/payment_orders/seb.rb
@@ -1,5 +1,5 @@
 module PaymentOrders
-  class Seb < EstonianBankLink
+  class SEB < EstonianBankLink
     def self.config_namespace_name
       'seb'
     end

--- a/app/views/admin/invoices/index.html.erb
+++ b/app/views/admin/invoices/index.html.erb
@@ -73,7 +73,7 @@
                     </th>
                     <th scope="col">
                         <%= t('invoices.paid_through') %>
-                        <%= sort_link_to "", "paid_through" %>
+                        <%= sort_link_to "", "channel" %>
                     </th>
                     <th></th>
                 </tr>

--- a/app/views/admin/invoices/index.html.erb
+++ b/app/views/admin/invoices/index.html.erb
@@ -40,8 +40,7 @@
                 <tr>
                     <th scope="col">
                         <%= t('invoices.billing_profile') %>
-                        <%#= order_buttons('invoices.billing_profile_id') %>
-                        <%= sort_link_to "", "billing_profile_id" %>
+                        <%= sort_link_to "", "billing_profile_name" %>
                     </th>
                     <th scope="col">
                         <%= t('invoices.due_date') %>

--- a/app/views/admin/invoices/index.html.erb
+++ b/app/views/admin/invoices/index.html.erb
@@ -60,7 +60,7 @@
                     </th>
                     <th scope="col">
                         <%= t('invoices.total') %>
-                        <%= sort_link_to "", "cents" %>
+                        <%= sort_link_to "", "total" %>
                     </th>
                     <th scope="col">
                         <%= t('invoices.vat_rate_on_payment') %>

--- a/app/views/auctions/_auction.html.erb
+++ b/app/views/auctions/_auction.html.erb
@@ -15,10 +15,10 @@
     </td>
     <td>
         <% if auction.platform == 'blind' || auction.platform.nil? %>
-            <span class="auctions-table-mobile-infotainment"><%= t('auctions.your_current_price') %>: </span><%= auction.users_price %>
+            <span class="auctions-table-mobile-infotainment"><%= t('auctions.your_current_price') %>: </span><%= number_with_precision(auction.users_price, precision: 2, separator: ",") %>
         <% else %>
             <span class="auctions-table-mobile-infotainment"><%= t('auctions.your_current_price') %>:</span>
-            <span class="initial-color current_<%= auction.currently_winning_offer&.user_id %>_user"><%= english_auction_presenter.maximum_bids %></span>
+            <span class="initial-color current_<%= auction.currently_winning_offer&.user_id %>_user"><%= number_with_precision(english_auction_presenter.maximum_bids, precision: 2, separator: ",") %></span>
         <% end %>
     </td>
     <td class="initial-color current_<%= auction.currently_winning_offer&.user_id %>_user">

--- a/app/views/auctions/index.html.erb
+++ b/app/views/auctions/index.html.erb
@@ -75,7 +75,7 @@
       <div class="four wide column"></div>
       <div class="four wide column"></div>
       <div class="four wide column" style='text-align: right;'>
-        <%= link_to t('auctions.finished_auctions'), histories_path, style: 'margin-bottom: 20px; display: block; font-size: 18px; color: #03456f;' %>
+        <%= link_to t('auctions.finished_auctions'), "#{histories_path}?direction=desc&sort=domain_name", style: 'margin-bottom: 20px; display: block; font-size: 18px; color: #03456f;' %>
       </div>
     </div>
     <div class="grid one column">

--- a/app/views/auctions/index.html.erb
+++ b/app/views/auctions/index.html.erb
@@ -111,7 +111,7 @@
                 <th class="four wide">
                   <span class='hide-table-header'>  
                     <%= t('auctions.offer_owner') %>
-                    <%= sort_link_to "", "platform" %>
+                    <%= sort_link_to "", "username" %>
                   </span>
                 </th>
                 <th class="auctions-table-cell-name-no-mobile center aligned"><%= t('auctions.offer_actions') %></th>

--- a/app/views/auctions/index.html.erb
+++ b/app/views/auctions/index.html.erb
@@ -105,7 +105,7 @@
                 <th class="auctions-table-cell-name-no-mobile">
                   <span class='hide-table-header'>
                     <%= t('auctions.current_price') %>
-                    <%= sort_link_to "", "users_offer_cents" %>
+                    <%= sort_link_to "", "users_price" %>
                   </span>
                 </th>
                 <th class="four wide">

--- a/app/views/histories/index.html.erb
+++ b/app/views/histories/index.html.erb
@@ -42,7 +42,7 @@
                       <div class="four wide column"></div>
 
                       <div class="four wide column" style='text-align: right;'>
-                        <%= link_to t('histories.current_auctions'), auctions_path, style: 'margin-bottom: 20px; display: block; font-size: 18px; color: #03456f;' %>
+                        <%= link_to t('histories.current_auctions'), auctions_path, style: 'margin-bottom: 20px; display: block; font-size: 18px; color: #03456f;', target: '_top' %>
                       </div>
                     </div>
 

--- a/app/views/histories/index.html.erb
+++ b/app/views/histories/index.html.erb
@@ -63,6 +63,7 @@
                                 </th>
                                 <th scope="col">
                                   <%= t('auctions.winning_bid') %>
+                                  <%= sort_link_to "", "users_price" %> 
                                 </th>
                                 <th scope="col">
                                   <%= t('auctions.auction_type') %>
@@ -79,7 +80,7 @@
                                     <td><%= auction.ends_at.to_formatted_s(:long) %></td>
                                     <td><%= auction.currently_winning_offer&.price if auction.platform == 'english' %></td>
                                     <td>
-                                        <%= t("auctions.#{auction.platform&.downcase.presence || 'blind'}") %>
+                                        <%= t("auctions.#{auction.platform&.downcase.presence || 'blind (lagacy)'}") %>
                                     </td>
                                 </tr>
                             <% end %>

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -14,3 +14,8 @@
 # ActiveSupport::Inflector.inflections(:en) do |inflect|
 #   inflect.acronym 'RESTful'
 # end
+
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym 'LHV'
+  inflect.acronym 'SEB'
+end

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,4 +1,6 @@
 require 'pagy/extras/overflow'
+require "pagy/extras/array"
+
 Pagy::I18n.load({ locale: 'en',
                   filepath: "#{Rails.root}/config/locales/pagy.en.yml" },
                 { locale: 'et',


### PR DESCRIPTION
**What do we have here?**
We have a sorting issue here. The problem is that things like the user's bid and username are being sorted incorrectly (actually, correctly), and there are also several issues with sorting in the admin panel. Here are the details: #1125 

**Why?**
The user's bids are actually sorted correctly, we just don't "see" it. The thing is, sorting is done by the Offer model, specifically by the 'cents' column. However, according to business logic, we only see bids made for the English auction, but we don't see bids made for the blind auction, even if they exist. So, we end up sorting the bids we see and the ones we don't, and that's why it seems to us that the sorting is wrong.

As for the fact that the user sorting doesn't occur - the answer is simple, it's just not implemented and another column of the table was specified instead.

Admin panel issue: domain names weren't sorted because of a simple typo in the column name, and sorting by deposit wasn't implemented at all.

The next issue was with class naming. The thing is, our records store record types in uppercase letters. For example, `PaymentOrder::LHV`, `PaymentOrder::SEB`. And these records expect there to be subclasses with the same names, specifically in uppercase. However, in Ruby on Rails, the naming logic is slightly different - it uses a capital letter followed by lowercase letters. So, the correct naming would be `PaymentOrder::Lhv`, `PaymentOrder::Seb`. Hence, there's a conflict with the naming. In the past, this all worked, but apparently, with the Ruby on Rails version update, this logic broke.

**Well, alright, what did you do?**
The main problem with implementing sorting was as follows: I can make it so that only English auctions are sorted, however, those users who placed a bid for blind auctions, they can see their bids. It turns out that in this implementation, only bids for the English auction will be sorted, and their bids for the blind will not be. Therefore, I had to complicate the SQL query so that bids for a specific user's blind auction were also included.

Implementing different business logic for sorting other columns also required SQL queries, but they are not as complex and convoluted as sorting by user bids.

I added exceptions to the inflections.rb file for the classes `PaymentOrder::LHV`, `PaymentOrder::SEB`, so Ruby wouldn't apply naming rules to them.

**How do we test all this?**
Testing is simple: just click on columns and ensure they are sorted correctly in alphabetical order. However, there are nuances for auction domain names for regular participants:

- [ ]     if you're a guest, you ONLY sort English auctions
- [ ]     if you're a participant but didn't place bids for the blind auction, you ONLY sort English auctions
- [ ]     if you're a participant, didn't place bids for the blind auction, but another user did, you ONLY sort English auctions
- [ ]     if you're a participant and placed a bid on a blind auction, you ONLY sort English auctions along with that blind auction where you placed a bid
- [ ]     if you're a participant and placed a bid on a blind auction, and another user also placed a bid on another blind auction, you ONLY sort English auctions and ONLY your blind auction.
- [ ]  It's necessary to ensure not only in the administrative part that the sorting works correctly but also that it works correctly for the user. 
- [ ] It's also necessary to check that the naming for `PaymentOrder` records for subclasses like `SEB` and `LHV` are in uppercase letters, and no others
