### PR TITLE
added missing billing profile vat code to invoice

### DIFF
--- a/app/views/common/pdf.html.erb
+++ b/app/views/common/pdf.html.erb
@@ -215,21 +215,22 @@
                     <hr/>
                     <dl class="dl-horizontal">
                         <dt>
-                            <%= t('billing_profiles.name') %>
+                          <%= t('billing_profiles.name') %>
                         </dt>
                         <dd>
-                            <%= @invoice.billing_name %>
+                          <%= @invoice.billing_name %>
                         </dd>
 
-                        <% if @invoice.billing_vat_code %>
-                            <dt><%= t('billing_profiles.vat_code') %></dt>
-                            <dd><%= @invoice.billing_vat_code %></dd>
+                        <% if @invoice.vat_code.present? %>                          
+                          <dt><%= t('billing_profiles.vat_code') %></dt>
+                          <dd>
+                                <%= @invoice.vat_code %>
+                          </dd>
                         <% end %>
-
 
                         <dt><%= t('billing_profiles.address') %></dt>
                         <dd>
-                            <%= @invoice.billing_address %>
+                          <%= @invoice.billing_address %>
                         </dd>
                     </dl>
                 </div>

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -21,6 +21,12 @@
             <div class="header"><%= @invoice.recipient %></div>
             <%= @invoice.address %>
           </div>
+          <% if @invoice.vat_code.present? %>
+            <div class="item">
+              <div class="header"><%= t('billing_profiles.vat_code') %></div>
+              <%= @invoice.vat_code %>
+            </div>
+          <% end %>
         </div>
       </div>
       <div class="column right aligned">
@@ -41,12 +47,6 @@
             <div class="item">
               <div class="header"><%= t('invoices.paid_at') %></div>
               <%= I18n.l(@invoice.paid_at) %>
-            </div>
-          <% end %>
-          <% if @invoice.vat_code.present? %>
-            <div class="item">
-              <div class="header"><%= t('billing_profiles.vat_code') %></div>
-              <%= @invoice.vat_code %>
             </div>
           <% end %>
         </div>

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -43,10 +43,10 @@
               <%= I18n.l(@invoice.paid_at) %>
             </div>
           <% end %>
-          <% if @invoice.billing_vat_code.present? %>
+          <% if @invoice.vat_code.present? %>
             <div class="item">
               <div class="header"><%= t('billing_profiles.vat_code') %></div>
-              <%= @invoice.billing_vat_code %>
+              <%= @invoice.vat_code %>
             </div>
           <% end %>
         </div>

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -43,6 +43,12 @@
               <%= I18n.l(@invoice.paid_at) %>
             </div>
           <% end %>
+          <% if @invoice.billing_vat_code.present? %>
+            <div class="item">
+              <div class="header"><%= t('billing_profiles.vat_code') %></div>
+              <%= @invoice.billing_vat_code %>
+            </div>
+          <% end %>
         </div>
       </div>
       <div class="column sixteen wide">

--- a/test/models/billing_profile_test.rb
+++ b/test/models/billing_profile_test.rb
@@ -160,7 +160,7 @@ class BillingProfileTest < ActiveSupport::TestCase
     assert_equal invoice.status, 'issued'
     assert_equal invoice.billing_name, 'New Company Ltd'
     assert_equal invoice.billing_address, @billing_profile.address
-    assert_equal invoice.billing_vat_code, 'DE123456789'
+    assert_equal invoice.billing_vat_code, '12345'
     assert_equal invoice.billing_alpha_two_country_code, @billing_profile.alpha_two_country_code
   end
 

--- a/test/models/billing_profile_test.rb
+++ b/test/models/billing_profile_test.rb
@@ -160,7 +160,7 @@ class BillingProfileTest < ActiveSupport::TestCase
     assert_equal invoice.status, 'issued'
     assert_equal invoice.billing_name, 'New Company Ltd'
     assert_equal invoice.billing_address, @billing_profile.address
-    assert_equal invoice.billing_vat_code, '12345'
+    assert_equal invoice.billing_vat_code, 'DE123456789'
     assert_equal invoice.billing_alpha_two_country_code, @billing_profile.alpha_two_country_code
   end
 


### PR DESCRIPTION
closed #1127 

What happened?
Judging by this error #1127, the specific invoice view is missing the user profile's VAT code for which the invoice was generated.

What did you do?
I added a condition: if the user has a VAT code, it should be displayed in the view; if not, it should be omitted.

How to test?
Simply check the invoice: if the invoice is generated for a billing profile that has a VAT code, then this code should be displayed in the view. If not, it should be absent. Another test scenario could be to generate an invoice for a billing profile that has a VAT code, and then delete that billing profile. In either case, the VAT code should be displayed.