### PR TITLE
added service object for notify billing about change status of deposit and added tests

### DIFF
--- a/app/controllers/admin/paid_deposit/deposit_statuses_controller.rb
+++ b/app/controllers/admin/paid_deposit/deposit_statuses_controller.rb
@@ -1,12 +1,25 @@
+# rubocop:disable Metrics
 module Admin
   class PaidDeposit::DepositStatusesController < BaseController
     def update
       @deposit = DomainParticipateAuction.find(params[:id])
 
+      deposits = DomainParticipateAuction.includes(:user).includes(:auction).search(params)
+      @pagy, @deposits = pagy(deposits, items: params[:per_page] ||= 15)
+
       if @deposit.update(status: params[:status])
-        redirect_to admin_paid_deposits_path, status: :see_other, flash: { notice: 'Invoice status updated successfully' }
+        res = @deposit.send_deposit_status_to_billing_system
+
+        if res.result?
+          redirect_to admin_paid_deposits_path, status: :see_other,
+                                                flash: { notice: 'Invoice status updated successfully' }
+        else
+          flash[:alert] = "Deposit status is updated in auction side, but got error from billing side: #{res.errors}"
+          redirect_to admin_paid_deposits_path, status: :see_other
+        end
       else
-        render 'admin/paid_deposits/index', status: :unprocessable_entity
+        flash[:alert] = @deposit.errors.full_messages.join(', ')
+        redirect_to admin_paid_deposits_path, status: :see_other
       end
     end
   end

--- a/app/models/domain_participate_auction.rb
+++ b/app/models/domain_participate_auction.rb
@@ -6,11 +6,15 @@ class DomainParticipateAuction < ApplicationRecord
 
   scope :search_by_auction_name_and_user_email, ->(origin) {
     if origin.present?
-      self.joins(:user).joins(:auction).where('users.email ILIKE ? OR auctions.domain_name ILIKE ?', "%#{origin}%", "%#{origin}%")
+      joins(:user).joins(:auction).where('users.email ILIKE ? OR auctions.domain_name ILIKE ?', "%#{origin}%", "%#{origin}%")
     end
   }
 
   def self.search(params = {})
-    self.search_by_auction_name_and_user_email(params[:search_string])
+    search_by_auction_name_and_user_email(params[:search_string])
+  end
+
+  def send_deposit_status_to_billing_system
+    EisBilling::DepositStatusService.call(domain_name: auction.domain_name, user_uuid: user.uuid, status: status)
   end
 end

--- a/app/services/eis_billing/deposit_status_service.rb
+++ b/app/services/eis_billing/deposit_status_service.rb
@@ -1,0 +1,38 @@
+module EisBilling
+  class DepositStatusService
+    include EisBilling::Request
+    include EisBilling::BaseService
+
+    attr_reader :user_uuid, :status, :domain_name
+
+    def initialize(user_uuid:, status:, domain_name:)
+      @user_uuid = user_uuid
+      @status = status
+      @domain_name = domain_name
+    end
+
+    def self.call(user_uuid:, status:, domain_name:)
+      new(user_uuid: user_uuid, status: status, domain_name:).call
+    end
+
+    def call
+      struct_response(fetch)
+    end
+
+    private
+
+    def fetch
+      post deposit_status_url, params
+    end
+
+    def params
+      { user_uuid: user_uuid,
+        domain_name: domain_name,
+        status: status }
+    end
+
+    def deposit_status_url
+      '/api/v1/invoice_generator/deposit_status'
+    end
+  end
+end

--- a/app/views/admin/paid_deposits/index.html.erb
+++ b/app/views/admin/paid_deposits/index.html.erb
@@ -67,11 +67,11 @@
                         <td><%= deposit.auction&.deposit %></td>
                         <td><%= link_to deposit&.auction&.domain_name, admin_auction_path(deposit.auction) %></td>
                         <td>
-                            <%= form_with url: admin_paid_deposit_deposit_status_path(deposit.id), method: :patch, 
-                                                                            data: { controller: 'autosave', target: 'autosave.form'} do |f| %>
-                                <%= f.select :status, options_for_select(DomainParticipateAuction.statuses.invert.values, deposit&.status), {},
-                                                selected: deposit&.status, data: { action: 'autosave#save', target: 'autosave.select' } %>
-                            <% end %> 
+                          <%= form_with url: admin_paid_deposit_deposit_status_path(deposit.id), method: :patch, 
+                              data: { controller: 'autosave', target: 'autosave.form', turbo: 'false'} do |f| %>
+                            <%= f.select :status, options_for_select(DomainParticipateAuction.statuses.invert.values, deposit&.status), {},
+                              selected: deposit&.status, data: { action: 'autosave#save', target: 'autosave.select' } %>
+                          <% end %>
                         </td>
                         </tr>
                     <% end %>

--- a/test/integration/admin/paid_deposits/deposit_statuses_test.rb
+++ b/test/integration/admin/paid_deposits/deposit_statuses_test.rb
@@ -38,4 +38,8 @@ class DepositStatusesTest < ActionDispatch::IntegrationTest
     d.reload
     assert_equal d.status, 'returned'
   end
+
+  def test_should_render_error_from_billing_side
+    # TODO: implement
+  end
 end

--- a/test/integration/admin/paid_deposits/deposit_statuses_test.rb
+++ b/test/integration/admin/paid_deposits/deposit_statuses_test.rb
@@ -8,6 +8,10 @@ class DepositStatusesTest < ActionDispatch::IntegrationTest
     @user = users(:participant)
     @admin = users(:administrator)
 
+    message = {"message": "Status updated"}
+    stub_request(:post, "http://eis_billing_system:3000/api/v1/invoice_generator/deposit_status")
+      .to_return(status: 200, body: message.to_json, headers: {})
+
     sign_in @admin
   end
 

--- a/test/services/deposit_status_service_test.rb
+++ b/test/services/deposit_status_service_test.rb
@@ -1,0 +1,38 @@
+require 'test_helper'
+
+class DepositStatusServiceTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    @auction = auctions(:english)
+    @user = users(:participant)
+    Spy.on_instance_method(EisBilling::BaseController, :authorized).and_return(true)
+  end
+
+  def test_call_fetches_data_from_billing_system
+    message = {"message": "Status updated"}
+    stub_request(:post, "http://eis_billing_system:3000/api/v1/invoice_generator/deposit_status")
+      .to_return(status: 200, body: message.to_json, headers: {})
+
+    d = DomainParticipateAuction.create(user_id: @user.id, auction_id: @auction.id)
+    d.update(status: 'returned')
+
+    res = d.send_deposit_status_to_billing_system
+
+    assert res.result?
+  end
+
+  def test_return_errors_in_struct_format
+    message = {"error": "Shit happens"}
+    stub_request(:post, "http://eis_billing_system:3000/api/v1/invoice_generator/deposit_status")
+      .to_return(status: 422, body: message.to_json, headers: {})
+
+    d = DomainParticipateAuction.create(user_id: @user.id, auction_id: @auction.id)
+    d.update(status: 'returned')
+
+    res = d.send_deposit_status_to_billing_system
+
+    refute res.result?
+    assert_equal res.errors, "Shit happens"
+  end
+end


### PR DESCRIPTION
close #1130 

**What's here?**
There is a problem with synchronizing the deposit status between the auction and the billing system. When the status is updated in the auction, no request notifies the billing system that the status needs to be updated, because there is no such implementation. This creates some complexity in determining who is the source of truth for the deposit status.

**How did you solve this problem?**
I created an endpoint on the billing system side that receives user data, auction data, and status: #https://github.com/internetee/eis_billing_system/pull/90. On the auction side, I created a service object that takes the necessary data and sends it to the auction.

**How to check?**
You need to check how different statuses are changed in the billing system when the administrator changes the deposit status in the auction.

**How to review?**

- Make sure the code is clean.
- Make sure the tests cover all functionalities.
- Ensure that the code does not add additional complexity and does not affect the functionality of other parts of the code.
