### PR TITLE
invoice synchronization with billing

### DIFF
--- a/app/controllers/eis_billing/base_controller.rb
+++ b/app/controllers/eis_billing/base_controller.rb
@@ -1,4 +1,6 @@
 module EisBilling
+  class InvoiceNotFound < StandardError; end
+
   class BaseController < ApplicationController
     protect_from_forgery with: :null_session
     # skip_authorization_check # Temporary solution

--- a/app/controllers/eis_billing/invoices_controller.rb
+++ b/app/controllers/eis_billing/invoices_controller.rb
@@ -1,0 +1,50 @@
+module EisBilling
+  class InvoicesController < EisBilling::BaseController
+    before_action :load_invoice
+
+    rescue_from InvoiceNotFound, with: :invoice_not_found
+
+    def update
+      state_machine
+
+      if @invoice.errors.any?
+        render json: { error: @invoice.errors }, status: :unprocessable_entity
+      else
+        render json: { message: 'Invoice data was successfully updated' },
+               status: :ok
+      end
+    end
+
+    private
+
+    def load_invoice
+      @invoice = ::Invoice.find_by(number: invoice_params[:invoice_number])
+      return if @invoice.present?
+
+      raise EisBilling::InvoiceNotFound
+    end
+
+    def invoice_params
+      params.require(:invoice).permit(:invoice_number)
+    end
+
+    def invoice_not_found
+      render json: {
+        error: {
+          message: "Invoice with #{invoice_params[:invoice_number]} number not found"
+        }
+      }, status: :not_found
+    end
+
+    def state_machine
+      case params[:status]
+      when 'unpaid'
+        @invoice.update(status: 'issued', paid_at: nil)
+      when 'paid'
+        @invoice.payable? ? @invoice.mark_as_paid_at(Time.zone.now) : @invoice.errors.add(:base, 'Invoice is not payable')
+      when 'cancelled'
+        @invoice.update(status: 'cancelled', paid_at: nil)
+      end
+    end
+  end
+end

--- a/app/models/invoice_cancellation.rb
+++ b/app/models/invoice_cancellation.rb
@@ -13,10 +13,10 @@ class InvoiceCancellation
       invoice.cancelled!
 
       response = EisBilling::SendInvoiceStatusService.call(invoice_number: invoice.number,
-                                                           status: 'cancelled')
+                                                           status: 'overdue')
       raise ActiveRecord::Rollback, response.errors unless response.result?
 
-      AutomaticBan.new(invoice: invoice, user: user, domain_name: domain_name).create if user
+      AutomaticBan.new(invoice:, user:, domain_name:).create if user
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,7 @@ Rails.application.routes.draw do
     put '/payment_status', to: 'payment_status#update', as: 'payment_status'
     put '/directo_response', to: 'directo_response#update', as: 'directo_response'
     put '/e_invoice_response', to: 'e_invoice_response#update', as: 'e_invoice_response'
+    resource :invoices, only: %i[update]
   end
 
   namespace :admin, constraints: Constraints::Administrator.new do

--- a/test/integration/eis_billing/invoices_test.rb
+++ b/test/integration/eis_billing/invoices_test.rb
@@ -1,0 +1,170 @@
+require 'test_helper'
+
+class InvoicesIntegrationTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    sign_in users(:participant)
+    @invoice = invoices(:payable)
+    Spy.on_instance_method(EisBilling::BaseController, :authorized).and_return(true)
+
+    stub_request(:patch, 'http://eis_billing_system:3000/api/v1/invoice/update_invoice_data')
+      .to_return(status: 200, body: @message.to_json, headers: {})
+  end
+
+  def test_update_issued_invoice_to_paid
+    assert @invoice.issued?
+
+    incoming_params = {
+      invoice: {
+        invoice_number: @invoice.number,
+        initiator: 'registry',
+        payment_reference: '93b29d54ae08f7728e72ee3fe0e88855cd1d266912039d7d23fa2b54b7e1b349',
+        transaction_amount: 120.0,
+        status: 'paid',
+        in_directo: false,
+        everypay_response: {
+          'some' => 'some'
+        },
+        sent_at_omniva: Time.zone.now - 10.minutes
+      },
+      status: 'paid'
+    }
+
+    put eis_billing_invoices_path, params: incoming_params
+
+    @invoice.reload
+    assert @invoice.paid?
+  end
+
+  def test_update_paid_invoice_to_issued
+    @invoice.update(status: 'paid', paid_at: Time.zone.now) && @invoice.reload
+    assert @invoice.paid?
+
+    incoming_params = {
+      invoice: {
+        invoice_number: @invoice.number,
+        initiator: 'registry',
+        payment_reference: '93b29d54ae08f7728e72ee3fe0e88855cd1d266912039d7d23fa2b54b7e1b349',
+        transaction_amount: 120.0,
+        status: 'paid',
+        in_directo: false,
+        everypay_response: {
+          'some' => 'some'
+        },
+        sent_at_omniva: Time.zone.now - 10.minutes
+      },
+      status: 'unpaid'
+    }
+
+    put eis_billing_invoices_path, params: incoming_params
+
+    @invoice.reload
+    assert @invoice.issued?
+  end
+
+  def test_update_issued_invoice_to_cancel
+    assert @invoice.issued?
+
+    incoming_params = {
+      invoice: {
+        invoice_number: @invoice.number,
+        initiator: 'registry',
+        payment_reference: '93b29d54ae08f7728e72ee3fe0e88855cd1d266912039d7d23fa2b54b7e1b349',
+        transaction_amount: 120.0,
+        status: 'paid',
+        in_directo: false,
+        everypay_response: {
+          'some' => 'some'
+        },
+        sent_at_omniva: Time.zone.now - 10.minutes
+      },
+      status: 'cancelled'
+    }
+
+    put eis_billing_invoices_path, params: incoming_params
+
+    @invoice.reload
+    assert @invoice.cancelled?
+  end
+
+  def test_update_paid_invoice_to_cancel
+    @invoice.update(status: 'paid', paid_at: Time.zone.now) && @invoice.reload
+    assert @invoice.paid?
+
+    incoming_params = {
+      invoice: {
+        invoice_number: @invoice.number,
+        initiator: 'registry',
+        payment_reference: '93b29d54ae08f7728e72ee3fe0e88855cd1d266912039d7d23fa2b54b7e1b349',
+        transaction_amount: 120.0,
+        status: 'paid',
+        in_directo: false,
+        everypay_response: {
+          'some' => 'some'
+        },
+        sent_at_omniva: Time.zone.now - 10.minutes
+      },
+      status: 'cancelled'
+    }
+
+    put eis_billing_invoices_path, params: incoming_params
+
+    @invoice.reload
+    assert @invoice.cancelled?
+  end
+
+  def test_cannot_change_status_from_cancelled_to_paid
+    @invoice.update(status: 'cancelled', paid_at: nil) && @invoice.reload
+    assert @invoice.cancelled?
+
+    incoming_params = {
+      invoice: {
+        invoice_number: @invoice.number,
+        initiator: 'registry',
+        payment_reference: '93b29d54ae08f7728e72ee3fe0e88855cd1d266912039d7d23fa2b54b7e1b349',
+        transaction_amount: 120.0,
+        status: 'paid',
+        in_directo: false,
+        everypay_response: {
+          'some' => 'some'
+        },
+        sent_at_omniva: Time.zone.now - 10.minutes
+      },
+      status: 'paid'
+    }
+
+    put eis_billing_invoices_path, params: incoming_params
+
+    assert_equal JSON.parse(response.body)["error"]["base"], ["Invoice is not payable"]
+
+    @invoice.reload
+    assert @invoice.cancelled?
+  end
+
+  def test_change_from_cancel_to_unpaid
+    @invoice.update(status: 'cancelled', paid_at: nil) && @invoice.reload
+    assert @invoice.cancelled?
+
+    incoming_params = {
+      invoice: {
+        invoice_number: @invoice.number,
+        initiator: 'registry',
+        payment_reference: '93b29d54ae08f7728e72ee3fe0e88855cd1d266912039d7d23fa2b54b7e1b349',
+        transaction_amount: 120.0,
+        status: 'paid',
+        in_directo: false,
+        everypay_response: {
+          'some' => 'some'
+        },
+        sent_at_omniva: Time.zone.now - 10.minutes
+      },
+      status: 'unpaid'
+    }
+
+    put eis_billing_invoices_path, params: incoming_params
+
+    @invoice.reload
+    assert @invoice.issued?
+  end
+end


### PR DESCRIPTION
**What have I done?**
I have added an endpoint that allows receiving account statuses from the billing side. This endpoint makes it possible to change the status of existing accounts to paid, issued, and canceled. It is also necessary to take into account that there are certain restrictions, for example, if an account is canceled, it cannot be changed to a "paid" status.

**How to test?**
Testing is done from the billing system side and is described here.
https://github.com/internetee/eis_billing_system/pull/100