### PR TITLE
changed vat rate calculation logic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,14 +26,12 @@ gem 'pg', '>= 0.18', '< 2.0'
 gem 'puma', '~> 6.4.0'
 gem 'rails', '>= 6.0.3.5'
 gem 'rails-i18n'
-# gem 'rails_semantic_logger'
 gem 'recaptcha'
 gem 'ruby-openai'
 gem 'scenic'
 gem 'simpleidn'
 gem 'skylight'
 gem 'sprockets', '~> 4.0'
-# gem 'turbolinks', '~> 5'
 gem 'turbo-rails'
 gem 'webpacker', '~> 6.0.0.rc.5'
 gem 'webpush'
@@ -49,6 +47,12 @@ group :development, :test do
 
   # https://github.com/rubocop/rubocop-performance
   gem 'rubocop-performance', require: false
+  gem "ruby-lsp"
+  gem "rubocop"
+  gem "rubocop-packaging"
+  gem "rubocop-rspec"
+  gem "rubocop-shopify"
+  gem "rubocop-thread_safety"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -264,6 +264,7 @@ GEM
     pg_search (2.3.6)
       activerecord (>= 5.2)
       activesupport (>= 5.2)
+    prism (0.19.0)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -346,9 +347,27 @@ GEM
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.29.0)
       parser (>= 3.2.1.0)
+    rubocop-capybara (2.19.0)
+      rubocop (~> 1.41)
+    rubocop-factory_bot (2.24.0)
+      rubocop (~> 1.33)
+    rubocop-packaging (0.5.2)
+      rubocop (>= 1.33, < 2.0)
     rubocop-performance (1.18.0)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
+    rubocop-rspec (2.25.0)
+      rubocop (~> 1.40)
+      rubocop-capybara (~> 2.17)
+      rubocop-factory_bot (~> 2.22)
+    rubocop-shopify (2.14.0)
+      rubocop (~> 1.51)
+    rubocop-thread_safety (0.5.1)
+      rubocop (>= 0.90.0)
+    ruby-lsp (0.13.2)
+      language_server-protocol (~> 3.17.0)
+      prism (>= 0.19.0, < 0.20)
+      sorbet-runtime (>= 0.5.5685)
     ruby-openai (4.2.0)
       faraday (>= 1)
       faraday-multipart (>= 1)
@@ -372,6 +391,7 @@ GEM
       unf (~> 0.1.4)
     skylight (5.3.4)
       activesupport (>= 5.2.0)
+    sorbet-runtime (0.5.11164)
     sprockets (4.2.0)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -474,7 +494,13 @@ DEPENDENCIES
   rails-i18n
   recaptcha
   redis (~> 5.0)
+  rubocop
+  rubocop-packaging
   rubocop-performance
+  rubocop-rspec
+  rubocop-shopify
+  rubocop-thread_safety
+  ruby-lsp
   ruby-openai
   scenic
   selenium-webdriver

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -119,6 +119,7 @@ class Invoice < ApplicationRecord
 
   def recalculate_vat_rate
     return if billing_profile_id == billing_profile_id_was
+    return unless payable?
 
     self.vat_rate = assign_vat_rate
   end

--- a/lib/tasks/assign_invoices_vat_rate.rake
+++ b/lib/tasks/assign_invoices_vat_rate.rake
@@ -1,7 +1,7 @@
 namespace :invoices do
   desc 'Assign vat rate to invoices what have vat rate of nil'
   task assign_invoices_vat_rate: :environment do
-    Invoice.where(vat_rate: nil, country_code: 'EE', vat_code: nil).in_batches do |batch_invoices|
+    Invoice.where(vat_rate: [nil, 0.0], country_code: 'EE').in_batches do |batch_invoices|
       batch_invoices.where('created_at < ?', '2024-01-01').update_all(vat_rate: 0.2)
       batch_invoices.where('created_at >= ?', '2024-01-01').update_all(vat_rate: 0.22)
     end

--- a/lib/tasks/assign_invoices_vat_rate.rake
+++ b/lib/tasks/assign_invoices_vat_rate.rake
@@ -1,0 +1,19 @@
+namespace :invoices do
+  desc 'Assign vat rate to invoices what have vat rate of nil'
+  task assign_invoices_vat_rate: :environment do
+    Invoice.where(vat_rate: nil, country_code: 'EE', vat_code: nil).in_batches do |batch_invoices|
+      batch_invoices.where('created_at < ?', '2024-01-01').update_all(vat_rate: 0.2)
+      batch_invoices.where('created_at >= ?', '2024-01-01').update_all(vat_rate: 0.22)
+    end
+
+    Invoice.where.not(country_code: 'EE').where(vat_rate: nil).in_batches do |batch_invoices|
+      batch_invoices.each do |invoice|
+        invoice.update(vat_rate: Countries.vat_rate_from_alpha2_code(invoice.country_code))
+      end
+    end
+
+    Invoice.where(vat_rate: nil).where.not(vat_code: nil).in_batches do |batch_invoices|
+      batch_invoices.update_all(vat_rate: 0.0)
+    end
+  end
+end

--- a/lib/tasks/assign_invoices_vat_rate.rake
+++ b/lib/tasks/assign_invoices_vat_rate.rake
@@ -6,14 +6,14 @@ namespace :invoices do
       batch_invoices.where('created_at >= ?', '2024-01-01').update_all(vat_rate: 0.22)
     end
 
+    Invoice.where(vat_rate: nil).where.not(vat_code: nil).in_batches do |batch_invoices|
+      batch_invoices.update_all(vat_rate: 0.0)
+    end
+
     Invoice.where.not(country_code: 'EE').where(vat_rate: nil).in_batches do |batch_invoices|
       batch_invoices.each do |invoice|
         invoice.update(vat_rate: Countries.vat_rate_from_alpha2_code(invoice.country_code))
       end
-    end
-
-    Invoice.where(vat_rate: nil).where.not(vat_code: nil).in_batches do |batch_invoices|
-      batch_invoices.update_all(vat_rate: 0.0)
     end
   end
 end

--- a/test/fixtures/invoices.yml
+++ b/test/fixtures/invoices.yml
@@ -20,6 +20,7 @@ payable:
   billing_address: "Baker Street 221B, NW1 6XE London, United Kingdom"
   billing_vat_code: "12234567890"
   billing_alpha_two_country_code: "GB"
+  vat_rate: 0.0
 
 orphaned:
   result: orphaned
@@ -39,3 +40,4 @@ orphaned:
   billing_name: "Orphan Profile"
   billing_address: "Baker Street 221B, NW1 6XE London, United Kingdom"
   billing_alpha_two_country_code: "GB"
+  vat_rate: 0.0


### PR DESCRIPTION
**What does this PR address?**

The issue here is related to the method override of the vat_rate column in the invoice table. It is expected that each invoice will have its unique vat_rate depending on the country associated with the user's billing profile, whether the user is an organization or an individual. However, due to the presence of the vat_rate method in the invoice model's code, it overrides the existing column, preventing data from being stored in the column and making the values dynamic. Additionally, since the Estonian income tax has been changed, these tax rate changes would also affect old invoices created before 2024.

To resolve this, it is necessary to eliminate this method and ensure that each invoice stores its own value so that changes in the tax rate do not affect old invoices.

**What do I need to know?**
In this PR, I have also included a rake task that allows you to go through all the accounts that do not have a vat rate and assign them a value. Ideally, this should be a separate PR and I will make it, because first the commands that assign the necessary values for the accounts are executed, and only then the current PR is deployed in production. This will help avoid errors, but for testing purposes, to simplify this PR, it also includes such a command: `rake invoices:assign_invoices_vat_rate`

**What does this command do?**
- It takes all accounts that do not have a Vat Rate, takes the code of Estonia and those that do not have a vat code. Then it checks when these accounts were created, if before 2024, it sets the vat rate value to 0.2, if after, 0.22.
- It takes all accounts that do not have a vat rate but do have a vat code and assigns them a vat rate of 0.
- It takes all accounts that are not from Estonia and where vat_rate is nil, and assigns them a vat rate depending on the value of the country code column
- When the user changes their billing profile, ensure that the payment amount also changes when the user switches to Everypay.
- Check directo and e-invoice omniva

**How to test?**
- Firstly, it is necessary to check the operation of the rake task and ensure that all the values assigned are correct for the invoices. The calculations should be taken in the context of Estonian accounts, considering when the account was created and whether the tax rate is correct. It is also important to take into account organizations and individuals from different countries.
- Subsequently, it is important to make sure that the correct values are assigned for Estonian accounts. Also, check that correct values are assigned for foreign accounts and organizations.
- Ensure that when changing the billing profile, the value of the active account is also correctly changed, while old accounts should not be altered.