### PR TITLE
solution for wrong vat rate for old invoices

### DIFF
--- a/app/controllers/payment_orders_controller.rb
+++ b/app/controllers/payment_orders_controller.rb
@@ -25,38 +25,6 @@ class PaymentOrdersController < ApplicationController
     @payment_order.callback_url = callback_payment_order_url(@payment_order.uuid)
   end
 
-  # # ANY /payment_orders/aa450f1a-45e2-4f22-b2c3-f5f46b5f906b/return
-  # def return
-  #   @payment_order = PaymentOrder.find_by!(uuid: params[:uuid])
-
-  #   if @payment_order.paid?
-  #     respond_to do |format|
-  #       format.html do
-  #         redirect_to invoices_path, notice: t('.already_paid') and return
-  #       end
-
-  #       format.json { render json: @payment_order.errors, status: :unprocessable_entity and return }
-  #     end
-  #   end
-
-  #   @payment_order.update!(response: params.to_unsafe_h)
-
-  #   ResultStatusUpdateJob.perform_later
-
-  #   respond_to do |format|
-  #     if @payment_order.mark_invoice_as_paid
-  #       format.html { redirect_to invoices_path, notice: successful_update_notice }
-  #       format.json { redirect_to invoices_path, notice: successful_update_notice }
-  #     else
-  #       format.html do
-  #         redirect_to invoices_path,
-  #                     notice: t('.not_successful')
-  #       end
-  #       format.json { render json: @payment_order.errors, status: :unprocessable_entity }
-  #     end
-  #   end
-  # end
-
   # POST /payment_orders/aa450f1a-45e2-4f22-b2c3-f5f46b5f906b/callback
   def callback
     render status: :ok, json: { status: 'ok' }
@@ -75,12 +43,6 @@ class PaymentOrdersController < ApplicationController
   def create_params
     params.require(:payment_order).permit(:user_id, :invoice_id, :invoice_ids, :type)
   end
-
-  # def successful_update_notice
-  #   invoice_ids = @payment_order.invoices.map(&:number).join(', ')
-  #   return t('.bulk_update', ids: invoice_ids) if @payment_order.invoices.count > 1
-  #   t(:updated)
-  # end
 
   def authorize_user
     authorize! :read, PaymentOrder

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -300,7 +300,6 @@ class Invoice < ApplicationRecord
 
   def prepare_payment_fields(time)
     self.paid_at = time
-    # self.vat_rate = billing_profile.present? ? billing_profile.vat_rate : vat_rate
     self.paid_amount = total
   end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -128,6 +128,7 @@ class Invoice < ApplicationRecord
   end
 
   def assign_vat_rate
+    return BigDecimal(OLD_EST_RATE_VAT, 2) if created_at < Date.new(2024, 1, 1) && country_code == 'EE'
     return BigDecimal(Setting.find_by(code: :estonian_vat_rate).retrieve, 2) if country_code == 'EE'
 
     return BigDecimal('0') if vat_code.present?
@@ -299,7 +300,7 @@ class Invoice < ApplicationRecord
 
   def prepare_payment_fields(time)
     self.paid_at = time
-    self.vat_rate = billing_profile.present? ? billing_profile.vat_rate : vat_rate
+    # self.vat_rate = billing_profile.present? ? billing_profile.vat_rate : vat_rate
     self.paid_amount = total
   end
 end

--- a/lib/tasks/assign_invoices_vat_rate.rake
+++ b/lib/tasks/assign_invoices_vat_rate.rake
@@ -16,4 +16,9 @@ namespace :invoices do
       end
     end
   end
+
+  task assign_values_to_old_invoices: :environment do
+    Invoice.where('created_at < ?', '2024-01-01').where(country_code: 'EE', vat_rate: 0.22)
+           .update_all(vat_rate: 0.2, in_directo: false)
+  end
 end

--- a/test/models/payment_orders/payment_order_every_pay_test.rb
+++ b/test/models/payment_orders/payment_order_every_pay_test.rb
@@ -51,46 +51,6 @@ class PaymentOrderEveryPayTest < ActiveSupport::TestCase
     travel_back
   end
 
-  # def test_form_fields_are_filled_according_to_schema
-  #   @orphaned_invoice.cents = Money.from_amount(1000.00, Setting.find_by(code: 'auction_currency').retrieve).cents
-  #   assert_equal Money.from_amount(1200.00, Setting.find_by(code: 'auction_currency').retrieve), @orphaned_invoice.total
-
-  #   expected_fields = {
-  #     api_username: 'api_user',
-  #     account_id: 'EUR3D1',
-  #     timestamp: '1522542600',
-  #     amount: '1200.00',
-  #     transaction_type: 'charge',
-  #     hmac_fields: 'account_id,amount,api_username,callback_url,customer_url,hmac_fields,locale,nonce,order_reference,timestamp,transaction_type',
-  #     locale: 'en',
-  #   }
-  #   form_fields = @every_pay.form_fields
-  #   expected_fields.each do |k, v|
-  #     assert_equal(v, form_fields[k])
-  #   end
-  # end
-
-  # def test_form_fields_with_estonian_locale
-  #   @every_pay.user = @user
-  #   @orphaned_invoice.cents = Money.from_amount(1234.56, Setting.find_by(code: 'auction_currency').retrieve).cents
-  #   assert_equal Money.from_amount(1481.47, Setting.find_by(code: 'auction_currency').retrieve), @orphaned_invoice.total
-  #   @user.update!(locale: :et)
-
-  #   expected_fields = {
-  #     api_username: 'api_user',
-  #     account_id: 'EUR3D1',
-  #     timestamp: '1522542600',
-  #     amount: '1481.47',
-  #     transaction_type: 'charge',
-  #     hmac_fields: 'account_id,amount,api_username,callback_url,customer_url,hmac_fields,locale,nonce,order_reference,timestamp,transaction_type',
-  #     locale: 'et',
-  #   }
-  #   form_fields = @every_pay.form_fields
-  #   expected_fields.each do |k, v|
-  #     assert_equal(v, form_fields[k])
-  #   end
-  # end
-
   def test_form_url_returns_the_constant
     assert_equal(PaymentOrders::EveryPay::URL, @every_pay.form_url)
   end
@@ -98,12 +58,6 @@ class PaymentOrderEveryPayTest < ActiveSupport::TestCase
   def test_channel
     assert_equal('EveryPay', @every_pay.channel)
   end
-
-  # def test_mark_invoice_as_paid_works_when_response_is_valid
-  #   @every_pay.mark_invoice_as_paid
-
-  #   assert(@every_pay.invoices.all?(&:paid?))
-  # end
 
   def test_mark_invoice_as_paid_does_not_work_when_response_is_invalid
     @fake_every_pay.mark_invoice_as_paid


### PR DESCRIPTION
**What does this PR do?**
This PR relates to this task #1222 . The essence is that old invoices that were created before the year 2024 and have the country code Estonia in the billing profile change to the wrong VAT rate after payment in the current year. It turns out that the user pays at a VAT rate of 20 percent, but after payment, the invoice is marked as though it was paid at 22 percent, which creates confusion for accounting.
However, there is another problem, if, say, a user has an old unpaid invoice from the year 2023 and they decide to change the billing profile for this invoice, a VAT rate of 22 percent will be set if the billing profile has the country code of Estonia - this is also incorrect. This PR solves these two problems.

**But what about invoices that already have incorrect data?**
For this, you need to run the task `rake invoices:assign_values_to_old_invoices`. This task takes all invoices that were created before the year 2024, which have the country code Estonia and which have a VAT rate of 22 percent, it changes the VAT rate to 20 percent, and also sets `in_directo = false`. The directo task will have to be run manually.

**How to test?**

- First, you need to try to reproduce the errors, how this can be done:
- Finish an auction and generate an invoice - then you need to change the values (issue_date, due_date, created_at, vat_rate) to last year's in this invoice and try to pay it, after that check what the values of the invoices are now.
- You also need to try to simply pay a regular invoice to make sure that the changes didn’t spoil anything.
- You also need to generate an invoice with last year's values for (issue_date, due_date, created_at, vat_rate) and for this invoice change the billing profile, for example, from foreign to Estonian, and make sure that for the Estonian billing profile VAT rate = 20%.
- You also need to generate an invoice with last year's values for (issue_date, due_date, created_at, vat_rate), however, set the VAT rate value to 22 percent and change in_directo to true, then run the task `rake invoices:assign_values_to_old_invoices` and check the result.
- After running the above task, make sure that this task did not affect other invoices that were created in the current year.