### PR TITLE
feat(auth): implement proper redirect after authentication

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 ruby:3.2.2-bullseye
+FROM ruby:3.2.2-bullseye
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -540,6 +540,7 @@ GEM
     zeitwerk (2.6.13)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin-23
   ruby
   x86_64-linux

--- a/app/views/notification_mailer/daily_auctions_broadcast_email.html.erb
+++ b/app/views/notification_mailer/daily_auctions_broadcast_email.html.erb
@@ -8,7 +8,7 @@
     <tbody>
         <% @auctions.each do |auction| %>
             <tr>
-                <td><%= auction.domain_name %></td>
+                <td><%= link_to auction.domain_name, "#{root_url}/auctions?type=all&domain_name=#{auction.domain_name}" %></td>
                 <td><%= auction.ends_at %></td>
             </tr>
         <% end %>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,6 +1,29 @@
 {
   "ignored_warnings": [
     {
+      "warning_type": "HTTP Verb Confusion",
+      "warning_code": 118,
+      "fingerprint": "18f43a662d06cf9cff347e48fb768f135e6e0a8a508e3976eede7dbeb05e8e3d",
+      "check_name": "VerbConfusion",
+      "message": "Potential HTTP verb confusion. `HEAD` is routed like `GET` but `request.get?` will return `false`",
+      "file": "app/controllers/application_controller.rb",
+      "line": 29,
+      "link": "https://brakemanscanner.org/docs/warning_types/http_verb_confusion/",
+      "code": "request.get? ? (request.fullpath) : (request.referer)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "ApplicationController",
+        "method": "store_location"
+      },
+      "user_input": "request.get?",
+      "confidence": "Weak",
+      "cwe_id": [
+        352
+      ],
+      "note": ""
+    },
+    {
       "warning_type": "Unmaintained Dependency",
       "warning_code": 120,
       "fingerprint": "d84924377155b41e094acae7404ec2e521629d86f97b0ff628e3d1b263f8101c",
@@ -17,7 +40,7 @@
       "cwe_id": [
         1104
       ],
-      "note": ""
+      "note": "Will update as soon as possible"
     }
   ],
   "brakeman_version": "7.0.0"


### PR DESCRIPTION
- Update authentication flow to properly store and restore user's location
- Implement Devise's recommended approach for handling redirects after sign in
- Fix redirect path after authentication to use stored location
- Update store_location method to handle both GET and non-GET requests
- Add proper location storage before authentication checks

This improves user experience by redirecting users back to their intended destination after signing in, rather than always going to root path.