### PR TITLE
fixed last bid column in offers view

### DIFF
--- a/app/controllers/offers_controller.rb
+++ b/app/controllers/offers_controller.rb
@@ -44,7 +44,11 @@ class OffersController < ApplicationController
 
   # GET /offers
   def index
-    offers = current_user.offers.search(params)
+    # Get highest offer for each auction
+    offers = current_user.offers.joins(:auction)
+                         .select('DISTINCT ON (auctions.id) offers.*, auctions.domain_name, auctions.platform, auctions.ends_at')
+                         .order('auctions.id, offers.cents DESC')
+                         .search(params)
     @pagy, @offers = pagy(offers, items: params[:per_page] ||= 15)
   end
 

--- a/app/views/offers/_offer.html.erb
+++ b/app/views/offers/_offer.html.erb
@@ -8,7 +8,7 @@
     <% end %>
   </h3></td>
   <td><%= component 'common/auction_type_icon', auction: offer.auction %></td>
-  <td><b><%= t('english_offers.index.your_last_offer') %>:</b> <%= t('offers.price_in_currency', price: offer.price) %></td>
+  <td><%= t('offers.price_in_currency', price: offer.auction.current_price_from_user(offer.user_id) || offer.price) %></td>
   <td><%= t('offers.price_in_currency', price: offer.total) %></td>
   <td><%= offer.auction.finished? ? t('auctions.finished') : tag.span(offer.auction.ends_at, data: { auction_timezone_target: 'endtime'}) %></td>
   

--- a/config/locales/offers.en.yml
+++ b/config/locales/offers.en.yml
@@ -32,7 +32,7 @@ en:
         Once the auction time has ended, we will send an email to
         the auction winner.
       participants: Bidder
-      your_last_offer: Last bid
+      your_last_offer: My bid
       offers_time: Time
       participants_title: Bidders
       deposit_title: Deposit Payments

--- a/config/locales/offers.et.yml
+++ b/config/locales/offers.et.yml
@@ -35,7 +35,7 @@ et:
       we_will_contact_winner: |
         Kui oksjon on lõppenud, saadameoksjoni võitjale e-kirja aadressile
       participants: Pakkuja
-      your_last_offer: Viimane pakkumine
+      your_last_offer: Minu pakkumus
       offers_time: Aeg
       participants_title: Pakkujad
       deposit_title: Deposiidimaksed


### PR DESCRIPTION
Fixed #1397

1. Changed in /offers view table english column name 'Last bid' to 'My bid'
2. Changed in /offers view table estonian column name 'Viimane pakkumine' to 'Minu pakkumus'
3. In column are displayed highest offer

![msedge_UYic1UsrOo](https://github.com/user-attachments/assets/c18cb776-efc5-470b-85bf-e0cc93bb8bec)
