### PR TITLE
removed total with VAT column

### DIFF
--- a/app/components/pages/offers/blind_auction_offer_table/component.html.erb
+++ b/app/components/pages/offers/blind_auction_offer_table/component.html.erb
@@ -4,7 +4,6 @@
           <td><h3><%= @offer.auction.domain_name  %></h3></td>
           <td><span data-auction-timezone-target="endtime"><%= @offer.auction.ends_at %></span></td>
           <td><%= t('offers.price_in_currency', price: @offer.price) %></td>
-          <td><%= t('offers.price_in_currency', price: @offer.total) %></td>
         </tr>
       <% end %>
     <% end %>

--- a/app/components/pages/offers/blind_auction_offer_table/component.rb
+++ b/app/components/pages/offers/blind_auction_offer_table/component.rb
@@ -13,8 +13,7 @@ module Pages
         def header_collection
           [{ column: nil, caption: t('auctions.domain_name'), options: { class: '' } },
            { column: nil, caption: t('auctions.ends_at'), options: { class: '' } },
-           { column: nil, caption: t('offers.price'), options: { class: '' } },
-           { column: nil, caption: t('offers.total'), options: { class: '' } }]
+           { column: nil, caption: t('offers.price'), options: { class: '' } }]
         end
       end
     end

--- a/app/components/pages/offers/english_auction_offer_table/component.html.erb
+++ b/app/components/pages/offers/english_auction_offer_table/component.html.erb
@@ -8,7 +8,6 @@
           <td><h3><%= @offer.auction.domain_name  %></h3></td>
           <td><span data-auction-timezone-target="endtime"><%= @offer.auction.ends_at %></span></td>
           <td><%= t('offers.price_in_currency', price: @offer.price) %></td>
-          <td><%= t('offers.price_in_currency', price: @offer.total) %></td>
         </tr>
       <% end %>
     <% end %>

--- a/app/components/pages/offers/english_auction_offer_table/component.rb
+++ b/app/components/pages/offers/english_auction_offer_table/component.rb
@@ -13,8 +13,7 @@ module Pages
         def overview_table_headers
           [{ column: nil, caption: t('auctions.domain_name'), options: { class: '' } },
            { column: nil, caption: t('auctions.ends_at'), options: { class: '' } },
-           { column: nil, caption: t('offers.price'), options: { class: '' } },
-           { column: nil, caption: t('offers.total'), options: { class: '' } }]
+           { column: nil, caption: t('offers.price'), options: { class: '' } }]
         end
 
         def bidder_table_headers

--- a/app/components/pages/offers/offers_table/component.rb
+++ b/app/components/pages/offers/offers_table/component.rb
@@ -14,7 +14,6 @@ module Pages
           [{ column: 'auctions.domain_name', caption: t('auctions.domain_name'), options: { class: 'sorting' } },
            { column: 'auctions.platform', caption: t('auctions.type'), options: { class: 'sorting' } },
            { column: nil, caption: t('offers.show.your_last_offer'), options: { class: '' } },
-           { column: nil, caption: t('offers.total'), options: { class: '' } },
            { column: 'auctions.ends_at', caption: t('auctions.ends_at'),
              options: { class: 'sorting' } },
            { column: nil, caption: t('result_name'), options: {} },

--- a/app/views/offers/_offer.html.erb
+++ b/app/views/offers/_offer.html.erb
@@ -9,7 +9,6 @@
   </h3></td>
   <td><%= component 'common/auction_type_icon', auction: offer.auction %></td>
   <td><b><%= t('english_offers.index.your_last_offer') %>:</b> <%= t('offers.price_in_currency', price: offer.price) %></td>
-  <td><%= t('offers.price_in_currency', price: offer.total) %></td>
   <td><%= offer.auction.finished? ? t('auctions.finished') : tag.span(offer.auction.ends_at, data: { auction_timezone_target: 'endtime'}) %></td>
   
   <td>


### PR DESCRIPTION
Issue #1396

Removed columns 'Total with VAT' from tables in: 

/offers
/offers/UUID
/english_offers/UUID

