### PR TITLE
Changed registrar link

### DIFF
--- a/app/components/common/header/component.html.erb
+++ b/app/components/common/header/component.html.erb
@@ -27,7 +27,7 @@
                         </ul>
                     </li>
                     <li>
-                        <a href="https://www.internet.ee/registrar-portal"><%= t('common.header.registrar_portal') %></a>
+                        <a href="<%= t('common.header.registrar_portal_url') %>"><%= t('common.header.registrar_portal') %></a>
                     </li>
                     <li>
                         <a href="https://registrant.internet.ee"><%= t('common.header.registrant_portal') %></a>

--- a/config/locales/common.en.yml
+++ b/config/locales/common.en.yml
@@ -4,6 +4,7 @@ en:
       open_portal: "Public portal"
       auction_portal: "Auction portal"
       registrar_portal_url_html: '<a href= "https://www.internet.ee/registrar-portal"><span>Registrar portal</span></a>'
+      registrar_portal_url: "https://registrar.internet.ee/en/login"
       registrar_portal: "Registrar portal"
       registrant_portal: "Registrant portal"
       notifications: "Notifications"

--- a/config/locales/common.et.yml
+++ b/config/locales/common.et.yml
@@ -3,7 +3,7 @@ et:
     header:
       open_portal: "Avalik portaal"
       auction_portal: "Oksjonikeskkond"
-      registrar_portal_url_html: '<a href= "https://registrar.internet.ee/et/login"><span>Registripidaja portaal</span></a>'
+      registrar_portal_url_html: '<a href= "https://www.internet.ee/registripidaja"><span>Registripidaja portaal</span></a>'
       registrar_portal_url: "https://registrar.internet.ee/et/login"
       registrar_portal: "Registripidaja portaal"
       registrant_portal: "Registreerija portaal"

--- a/config/locales/common.et.yml
+++ b/config/locales/common.et.yml
@@ -3,7 +3,8 @@ et:
     header:
       open_portal: "Avalik portaal"
       auction_portal: "Oksjonikeskkond"
-      registrar_portal_url_html: '<a href= "https://www.internet.ee/registripidaja"><span>Registripidaja portaal</span></a>'
+      registrar_portal_url_html: '<a href= "https://registrar.internet.ee/et/login"><span>Registripidaja portaal</span></a>'
+      registrar_portal_url: "https://registrar.internet.ee/et/login"
       registrar_portal: "Registripidaja portaal"
       registrant_portal: "Registreerija portaal"
       notifications: "Teavitused"


### PR DESCRIPTION
Fixes: #1403
On Auction portal page main menu link 'Oksjonikeskkond'/'Registrar portal' was changed from info to login links. 
Both estonian and english accordingly:

https://www.internet.ee/registripidaja -> https://registrar.internet.ee/en/login
https://www.internet.ee/registrar-portal -> https://registrar.internet.ee/et/login



<img width="1612" height="1225" alt="msedge_ViUvpz7bA8" src="https://github.com/user-attachments/assets/2cb6d223-77f0-4474-9614-6d00d476790f" />
