### PR TITLE
Fixed Auction Filter component initializer

### DIFF
--- a/app/components/captcha/component.rb
+++ b/app/components/captcha/component.rb
@@ -3,7 +3,7 @@ module Captcha
     attr_reader :show_checkbox_recaptcha, :captcha_required, :action
 
     def initialize(captcha_required:, show_checkbox_recaptcha:, action:)
-      super
+      super()
 
       @show_checkbox_recaptcha = show_checkbox_recaptcha
       @captcha_required = captcha_required

--- a/app/components/common/action_button/component.rb
+++ b/app/components/common/action_button/component.rb
@@ -4,7 +4,7 @@ module Common
       attr_reader :type, :href, :color, :options
 
       def initialize(type:, href:, color: 'ghost', options: {})
-        super
+        super()
 
         @type = type
         @href = href

--- a/app/components/common/auction_type_icon/component.rb
+++ b/app/components/common/auction_type_icon/component.rb
@@ -6,7 +6,7 @@ module Common
       def initialize(auction:)
         @auction = auction
 
-        super
+        super()
       end
 
       def english?

--- a/app/components/common/badgets/component.rb
+++ b/app/components/common/badgets/component.rb
@@ -4,7 +4,7 @@ module Common
       attr_reader :status
 
       def initialize(status:)
-        super
+        super()
 
         @status = status
       end

--- a/app/components/common/buttons/button_to/component.rb
+++ b/app/components/common/buttons/button_to/component.rb
@@ -5,7 +5,7 @@ module Common
         attr_reader :title_caption, :href, :color, :options
 
         def initialize(href:, title_caption: nil, color: 'blue-secondary', options: {})
-          super
+          super()
 
           @title_caption = title_caption
           @href = href

--- a/app/components/common/buttons/delete_button_with_text/component.rb
+++ b/app/components/common/buttons/delete_button_with_text/component.rb
@@ -5,7 +5,7 @@ module Common
         attr_reader :path, :text
 
         def initialize(path:, text:)
-          super
+          super()
 
           @path = path
           @text = text

--- a/app/components/common/form/checkboxes/checkbox_with_label/component.rb
+++ b/app/components/common/form/checkboxes/checkbox_with_label/component.rb
@@ -6,7 +6,7 @@ module Common
           attr_reader :label_title, :form, :attribute, :options
 
           def initialize(label_title:, form:, attribute:, options: {})
-            super
+            super()
 
             @label_title = label_title
             @form = form

--- a/app/components/common/form/checkboxes/rounded_checkbox/component.rb
+++ b/app/components/common/form/checkboxes/rounded_checkbox/component.rb
@@ -6,7 +6,7 @@ module Common
           attr_reader :attribute, :form, :options
 
           def initialize(form:, attribute:, options: {})
-            super
+            super()
 
             @form = form
             @attribute = attribute

--- a/app/components/common/form/dropdown_input/component.rb
+++ b/app/components/common/form/dropdown_input/component.rb
@@ -5,7 +5,7 @@ module Common
         attr_reader :form, :attribute, :enum, :first_options, :second_options
 
         def initialize(form:, attribute:, enum:, first_options: {}, second_options: {})
-          super
+          super()
 
           @form = form
           @attribute = attribute

--- a/app/components/common/form/email_field/component.rb
+++ b/app/components/common/form/email_field/component.rb
@@ -6,7 +6,7 @@ module Common
         attr_reader :form, :attribute, :options
 
         def initialize(form:, attribute:, options:)
-          super
+          super()
 
           @form = form
           @attribute = attribute

--- a/app/components/common/form/form_button/component.rb
+++ b/app/components/common/form/form_button/component.rb
@@ -5,7 +5,7 @@ module Common
         attr_reader :btn_title, :form, :color, :options
 
         def initialize(btn_title:, form:, color: 'green', options: {})
-          super
+          super()
 
           @btn_title = btn_title
           @form = form

--- a/app/components/common/form/label/component.rb
+++ b/app/components/common/form/label/component.rb
@@ -5,7 +5,7 @@ module Common
         attr_reader :attribute, :form, :title, :options
 
         def initialize(attribute:, form:, title: nil, options: {})
-          super
+          super()
 
           @attribute = attribute
           @form = form

--- a/app/components/common/form/number_field/component.rb
+++ b/app/components/common/form/number_field/component.rb
@@ -6,7 +6,7 @@ module Common
         attr_reader :form, :attribute, :options
 
         def initialize(form:, attribute:, options: {})
-          super
+          super()
 
           @form = form
           @attribute = attribute

--- a/app/components/common/form/password_field/component.rb
+++ b/app/components/common/form/password_field/component.rb
@@ -6,7 +6,7 @@ module Common
         attr_reader :form, :attribute, :options
 
         def initialize(form:, attribute:, options:)
-          super
+          super()
 
           @form = form
           @attribute = attribute

--- a/app/components/common/form/password_field/description/component.rb
+++ b/app/components/common/form/password_field/description/component.rb
@@ -6,7 +6,7 @@ module Common
           attr_reader :form, :attribute, :minimum_password_length, :user
 
           def initialize(form:, attribute:, minimum_password_length:, user:)
-            super
+            super()
 
             @form = form
             @attribute = attribute

--- a/app/components/common/form/radio_button/component.rb
+++ b/app/components/common/form/radio_button/component.rb
@@ -5,7 +5,7 @@ module Common
         attr_reader :form, :title, :attribute, :data_attributes, :style, :checkbox_id, :checked
 
         def initialize(form:, title:, attribute:, data_attributes:, options: {})
-          super
+          super()
 
           @form = form
           @title = title

--- a/app/components/common/form/search_field/component.rb
+++ b/app/components/common/form/search_field/component.rb
@@ -5,7 +5,7 @@ module Common
         attr_reader :form, :attribute, :value, :placeholder
 
         def initialize(form:, attribute:, value:, placeholder:)
-          super
+          super()
 
           @form = form
           @attribute = attribute

--- a/app/components/common/form/telephone_field/component.rb
+++ b/app/components/common/form/telephone_field/component.rb
@@ -5,7 +5,7 @@ module Common
         attr_reader :attribute, :form, :options
 
         def initialize(form:, attribute:, options: {})
-          super
+          super()
 
           @form = form
           @attribute = attribute

--- a/app/components/common/form/text_field/component.rb
+++ b/app/components/common/form/text_field/component.rb
@@ -6,7 +6,7 @@ module Common
         attr_reader :form, :attribute, :options
 
         def initialize(form:, attribute:, options: {})
-          super
+          super()
 
           @form = form
           @attribute = attribute

--- a/app/components/common/header/component.rb
+++ b/app/components/common/header/component.rb
@@ -6,7 +6,7 @@ module Common
       attr_reader :notifications
 
       def initialize(notifications:)
-        super
+        super()
 
         @notifications = notifications
       end

--- a/app/components/common/header/notification/component.rb
+++ b/app/components/common/header/notification/component.rb
@@ -5,7 +5,7 @@ module Common
         attr_reader :notifications
 
         def initialize(notifications:)
-          super
+          super()
 
           @notifications = notifications
         end

--- a/app/components/common/hero/component.rb
+++ b/app/components/common/hero/component.rb
@@ -5,7 +5,7 @@ module Common
       attr_reader :title
 
       def initialize(title:)
-        super
+        super()
 
         @title = title
       end

--- a/app/components/common/links/link_button/component.rb
+++ b/app/components/common/links/link_button/component.rb
@@ -5,7 +5,7 @@ module Common
         attr_reader :link_title, :href, :color, :css_class_as_login, :options
 
         def initialize(link_title: nil, href:, css_class_as_login: false, color: 'green', options: {})
-          super
+          super()
 
           @link_title = link_title
           @href = href

--- a/app/components/common/notifications/icon/component.rb
+++ b/app/components/common/notifications/icon/component.rb
@@ -8,7 +8,7 @@ module Common
           @notification_type = notification.type
           @readed = readed
 
-          super
+          super()
         end
       end
     end

--- a/app/components/common/pagy/component.rb
+++ b/app/components/common/pagy/component.rb
@@ -8,7 +8,7 @@ module Common
       def initialize(pagy:)
         @pagy = pagy
 
-        super
+        super()
       end
     end
   end

--- a/app/components/common/static_notice/component.rb
+++ b/app/components/common/static_notice/component.rb
@@ -4,7 +4,7 @@ module Common
       attr_accessor :current_user
 
       def initialize(current_user:)
-        super
+        super()
 
         @current_user = current_user
       end

--- a/app/components/common/table/component.rb
+++ b/app/components/common/table/component.rb
@@ -7,7 +7,7 @@ module Common
         @header_collection = header_collection
         @options = options
 
-        super
+        super()
       end
 
       def table_header_generator

--- a/app/components/common/timer/component.rb
+++ b/app/components/common/timer/component.rb
@@ -4,7 +4,7 @@ module Common
       attr_reader :auction
 
       def initialize(auction:)
-        super
+        super()
 
         @auction = auction
       end

--- a/app/components/modals/change_offer/component.rb
+++ b/app/components/modals/change_offer/component.rb
@@ -4,7 +4,7 @@ module Modals
       attr_reader :offer, :auction, :autobider, :update, :current_user, :captcha_required, :show_checkbox_recaptcha
 
       def initialize(offer:, auction:, autobider:, update:, current_user:, captcha_required:, show_checkbox_recaptcha:)
-        super
+        super()
 
         @offer = offer
         @auction = auction

--- a/app/components/modals/change_offer/number_form_field/component.rb
+++ b/app/components/modals/change_offer/number_form_field/component.rb
@@ -5,7 +5,7 @@ module Modals
         attr_reader :offer_value, :offer_disabled
 
         def initialize(offer_value:, offer_disabled:)
-          super
+          super()
 
           @offer_value = offer_value
           @offer_disabled = offer_disabled

--- a/app/components/modals/change_offer_po/component.rb
+++ b/app/components/modals/change_offer_po/component.rb
@@ -4,7 +4,7 @@ module Modals
       attr_reader :offer, :auction, :update, :current_user, :captcha_required, :show_checkbox_recaptcha
 
       def initialize(offer:, auction:, update:, current_user:, captcha_required:, show_checkbox_recaptcha:)
-        super
+        super()
 
         @offer = offer
         @auction = auction

--- a/app/components/modals/delete_offer/component.rb
+++ b/app/components/modals/delete_offer/component.rb
@@ -4,7 +4,7 @@ module Modals
       attr_reader :offer
 
       def initialize(offer:)
-        super
+        super()
 
         @offer = offer
       end

--- a/app/components/modals/deposit/component.rb
+++ b/app/components/modals/deposit/component.rb
@@ -4,7 +4,7 @@ module Modals
       attr_reader :auction, :current_user, :captcha_required
 
       def initialize(auction:, current_user:, captcha_required:, show_checkbox_recaptcha:)
-        super
+        super()
 
         @auction = auction
         @current_user = current_user

--- a/app/components/modals/forgot_password/component.rb
+++ b/app/components/modals/forgot_password/component.rb
@@ -6,7 +6,7 @@ module Modals
       attr_reader :resource, :resource_name
 
       def initialize(resource:, resource_name:)
-        super
+        super()
 
         @resource = resource
         @resource_name = resource_name

--- a/app/components/modals/no_reset_password_link/component.rb
+++ b/app/components/modals/no_reset_password_link/component.rb
@@ -6,7 +6,7 @@ module Modals
       attr_reader :resource, :resource_name
 
       def initialize(resource:, resource_name:)
-        super
+        super()
 
         @resource = resource
         @resource_name = resource_name

--- a/app/components/modals/pay_invoice/component.rb
+++ b/app/components/modals/pay_invoice/component.rb
@@ -4,7 +4,7 @@ module Modals
       attr_reader :invoice
 
       def initialize(invoice:)
-        super
+        super()
 
         @invoice = invoice
       end

--- a/app/components/modals/pay_invoice/invoice_information/component.rb
+++ b/app/components/modals/pay_invoice/invoice_information/component.rb
@@ -5,7 +5,7 @@ module Modals
         attr_reader :invoice
 
         def initialize(invoice:)
-          super
+          super()
   
           @invoice = invoice
         end

--- a/app/components/modals/winner_domain/component.rb
+++ b/app/components/modals/winner_domain/component.rb
@@ -4,7 +4,7 @@ module Modals
       attr_reader :result
 
       def initialize(result:)
-        super
+        super()
 
         @result = result
       end

--- a/app/components/pages/auction/auction_action_button/component.rb
+++ b/app/components/pages/auction/auction_action_button/component.rb
@@ -5,7 +5,7 @@ module Pages
         attr_reader :user, :auction, :updated
 
         def initialize(user:, auction:, updated: false)
-          super
+          super()
 
           @user = user
           @auction = auction

--- a/app/components/pages/auction/auction_action_button/edit_and_remove_blind_offer/component.rb
+++ b/app/components/pages/auction/auction_action_button/edit_and_remove_blind_offer/component.rb
@@ -6,7 +6,7 @@ module Pages
           attr_reader :user, :auction
 
           def initialize(user:, auction:)
-            super
+            super()
 
             @user = user
             @auction = auction

--- a/app/components/pages/auction/auction_action_button/edit_english_offer/component.rb
+++ b/app/components/pages/auction/auction_action_button/edit_english_offer/component.rb
@@ -6,7 +6,7 @@ module Pages
           attr_reader :auction
 
           def initialize(auction:)
-            super
+            super()
 
             @auction = auction
           end

--- a/app/components/pages/auction/filter/component.rb
+++ b/app/components/pages/auction/filter/component.rb
@@ -5,7 +5,7 @@ module Pages
         attr_reader :current_user
 
         def initialize(current_user:)
-          super
+          super()
 
           @current_user = current_user
         end

--- a/app/components/pages/auction/notification_subscribe/component.rb
+++ b/app/components/pages/auction/notification_subscribe/component.rb
@@ -5,7 +5,7 @@ module Pages
         attr_reader :current_user
 
         def initialize(current_user:)
-          super
+          super()
 
           @current_user = current_user
         end

--- a/app/components/pages/invoices/outstanding_invoices/component.rb
+++ b/app/components/pages/invoices/outstanding_invoices/component.rb
@@ -7,7 +7,7 @@ module Pages
 
         def initialize(issued_invoices:, cancelled_payable_invoices:, cancelled_expired_invoices:,
                        unpaid_invoices_count:)
-          super
+          super()
 
           @issued_invoices = issued_invoices
           @cancelled_payable_invoices = cancelled_payable_invoices

--- a/app/components/pages/invoices/paid_invoices/component.rb
+++ b/app/components/pages/invoices/paid_invoices/component.rb
@@ -5,7 +5,7 @@ module Pages
         attr_reader :paid_invoices, :deposit_paid
 
         def initialize(paid_invoices:, deposit_paid:)
-          super
+          super()
 
           @paid_invoices = paid_invoices
           @deposit_paid = deposit_paid

--- a/app/components/pages/offers/blind_auction_offer_table/component.rb
+++ b/app/components/pages/offers/blind_auction_offer_table/component.rb
@@ -5,7 +5,7 @@ module Pages
         attr_reader :offer
 
         def initialize(offer:)
-          super
+          super()
 
           @offer = offer
         end

--- a/app/components/pages/offers/english_auction_offer_table/component.rb
+++ b/app/components/pages/offers/english_auction_offer_table/component.rb
@@ -5,7 +5,7 @@ module Pages
         attr_reader :offer
 
         def initialize(offer:)
-          super
+          super()
 
           @offer = offer
         end

--- a/app/components/pages/offers/offers_table/component.rb
+++ b/app/components/pages/offers/offers_table/component.rb
@@ -5,7 +5,7 @@ module Pages
         attr_reader :offers
 
         def initialize(offers:)
-          super
+          super()
 
           @offers = offers
         end


### PR DESCRIPTION
Close #1445
Fixed Auction Filter component initializer to avoid argument forwarding to superclass.
Reason: calling super (without parentheses) forwards the keyword arg to the parent initialize, which expects 0 args. Using super() calls the parent with no arguments