### PR TITLE
Fix locale persistence after TARA authentication

### DIFF
--- a/app/controllers/auth/tara_controller.rb
+++ b/app/controllers/auth/tara_controller.rb
@@ -5,6 +5,10 @@ module Auth
       notify_airbrake(e)
     end
 
+    before_action do
+      I18n.locale = @user&.locale || cookies[:locale] || I18n.default_locale
+    end
+
     def callback
       intended_redirect_path = stored_location_for(:user) || root_path
       session[:omniauth_hash] = user_hash.delete_if { |key, _| key == 'credentials' }

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -90,6 +90,10 @@ en:
           Sign in using an Estonian (incl. e-residents) ID card, mobile ID,
           Bank link or other EU citizen's electronic ID supported by EIDAS.
         sign_in_with_password: "Sign in with a password"
+      user:
+        signed_in: "Signed in successfully."
+        signed_out: "Signed out successfully."
+        already_signed_out: "Signed out successfully."
       signed_in: "Signed in successfully."
       signed_out: "Signed out successfully."
       already_signed_out: "Signed out successfully."


### PR DESCRIPTION
Ensures user locale preference is maintained after EEID login by adding before_action filter to restore locale from user settings, cookies, or default. Also adds missing Devise flash message translations under user scope to properly display localized sign in/out messages.

Fixes #1474 