### PR TITLE
Update Notification model for Noticed 2.x compatibility

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,6 +1,25 @@
 class Notification < ApplicationRecord
-  include Noticed::Model
+  include Noticed::Deliverable
   belongs_to :recipient, polymorphic: true
+
+  scope :unread, -> { where(read_at: nil) }
+  scope :read, -> { where.not(read_at: nil) }
+
+  def mark_as_read!
+    update!(read_at: Time.current)
+  end
+
+  def mark_as_unread!
+    update!(read_at: nil)
+  end
+
+  def read?
+    read_at.present?
+  end
+
+  def unread?
+    read_at.nil?
+  end
 
   # after_create_commit :broadcast_to_bell
   # after_create_commit :broadcast_to_recipient


### PR DESCRIPTION
- Replace Noticed::Model with Noticed::Deliverable
- Add unread and read scopes for filtering notifications
- Implement mark_as_read! and mark_as_unread! methods
- Add read? and unread? helper methods for status checking

This fixes compatibility issues after upgrading to noticed gem version 2.9.3