### PR TITLE
Allow comma on Billing Profile 'Street' field

### DIFF
--- a/app/models/concerns/safe_value_validator.rb
+++ b/app/models/concerns/safe_value_validator.rb
@@ -4,7 +4,7 @@ class SafeValueValidator < ActiveModel::EachValidator
 
     # Regexp for latin characters lower/upper-case
     unicode_chars = /\p{Latin}/
-    if %r{[^a-zA-Z#{unicode_chars.source}\/\d\s\/\'\’\-\.]}.match?(value)
+    if %r{[^a-zA-Z#{unicode_chars.source}\/\d\s\/\'\'\-\.\,]}.match?(value)
       record.errors.add(attribute, I18n.t('.value_is_not_safe'))
       return false
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -115,7 +115,7 @@ en:
   invalid: "invalid"
   value_is_not_safe: |
     Please note that the only characters allowed are UTF-characters of english/estonian alphabet,
-    numbers, forward slashes, apostrophes, dots and hyphens.
+    numbers, forward slashes, apostrophes, dots, hyphens and commas.
   not_accepted: "Not accepted"
   not_confirmed: "Not confirmed"
   details: "Details"

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -92,7 +92,7 @@ et:
   invalid: "vale"
   value_is_not_safe: |
     Nime ja aadressi andmetes on lubatud kasutada vaid inglise ja eesti tähestiku tähti, numbreid,
-    punkti, ülakoma ning kald- ja sidekriipsu
+    punkti, ülakoma, koma ning kald- ja sidekriipsu
   not_accepted: "Tagasi lükatud"
   not_confirmed: "Kinnitamata"
   details: "Detailid"


### PR DESCRIPTION
close #1502 

With this pull request it is allowed to add comma on 'Street' input field for Billing Profile.