### PR TITLE
Error message will not display on correct data input - Billing Profiles

### DIFF
--- a/app/controllers/billing_profiles_controller.rb
+++ b/app/controllers/billing_profiles_controller.rb
@@ -87,7 +87,7 @@ class BillingProfilesController < ApplicationController
         format.html { redirect_to billing_profiles_path, notice: t(:updated) }
         format.json { render :show, status: :ok, location: @billing_profile }
       else
-        flash[:alert] = @billing_profile.errors.full_messages.to_sentence
+        flash.now[:alert] = @billing_profile.errors.full_messages.to_sentence
 
         format.turbo_stream do
           render turbo_stream: [


### PR DESCRIPTION
close #1503 

## Problem
Error messages from failed billing profile updates were showing alongside success messages on subsequent successful updates.

## Solution
Changed error handling in `BillingProfilesController#update` to use `flash.now[:alert]` instead of `flash[:alert]`, ensuring error messages are cleared after the current request. 