### PR TITLE
Fix test runs that failed on empty billing_secret string

### DIFF
--- a/config/customization.yml.sample
+++ b/config/customization.yml.sample
@@ -117,7 +117,7 @@ default: &default
     secret_access_word: 'please-Give-Me-accesS'
     secret_word: 'this-secret-should-be-change'
     billing_system_integrated: 'true'
-    billing_secret: ''
+    billing_secret: 'test-billing-secret'
 
 development:
   <<: *default


### PR DESCRIPTION
close #1591 

jwt patch update 2.10.2 -> 2.10.3 broke CI test runs because empty string on billing_secret
because 2.10.3 does not allow anymore nil or empty string.

This PR will fix test run.