### PR TITLE
Bump faraday and fix bundle-audit vulnerabilities

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'delayed_job_active_record'
 gem 'devise', '>= 5.0.3'
 gem 'directo', github: 'internetee/directo', branch: 'master'
 gem 'faker'
-gem 'faraday', '>= 2.14.1'
+gem 'faraday', '>= 2.14.3'
 gem 'freezolite', require: false
 gem 'hotwire-rails', '~> 0.1.3'
 gem 'jbuilder', '~> 2.11'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,12 +131,12 @@ GEM
     childprocess (5.1.0)
       logger (~> 1.5)
     coderay (1.1.3)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
     crack (1.0.0)
       bigdecimal
       rexml
-    crass (1.0.6)
+    crass (1.0.7)
     cssbundling-rails (1.4.3)
       railties (>= 6.0.0)
     csv (3.3.5)
@@ -311,7 +311,7 @@ GEM
     minitest-mock (5.27.0)
     money (6.19.0)
       i18n (>= 0.6.4, <= 2)
-    msgpack (1.8.0)
+    msgpack (1.8.3)
     multipart-post (2.4.1)
     mutex_m (0.3.0)
     net-http (0.9.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -519,9 +519,6 @@ GEM
       faraday-multipart (>= 1)
     ruby-progressbar (1.13.0)
     rubyzip (3.1.0)
-    sass-embedded (1.93.2)
-      google-protobuf (~> 4.31)
-      rake (>= 13)
     sass-embedded (1.93.2-aarch64-linux-gnu)
       google-protobuf (~> 4.31)
     sass-embedded (1.93.2-aarch64-linux-musl)
@@ -646,7 +643,7 @@ DEPENDENCIES
   devise (>= 5.0.3)
   directo!
   faker
-  faraday (>= 2.14.1)
+  faraday (>= 2.14.3)
   foreman
   freezolite
   hotwire-rails (~> 0.1.3)


### PR DESCRIPTION
## Summary

- Bump the `faraday` minimum version from `>= 2.14.1` to `>= 2.14.3` to pick up recent security fixes.
- Update transitive dependencies that were failing `bundle-audit` in CI:
  - `concurrent-ruby` 1.3.6 → 1.3.7 (CVE-2026-54904, CVE-2026-54905, CVE-2026-54906)
  - `crass` 1.0.6 → 1.0.7 (GHSA-6jxj-px6v-747w, GHSA-6wmf-3r64-vcwv, GHSA-8vfg-2r28-hvhj, GHSA-wwpr-jff3-395c)
  - `msgpack` 1.8.0 → 1.8.3 (CVE-2026-54522)
- Regenerate `Gemfile.lock` with `bundle update concurrent-ruby crass msgpack`.

No application code changes; dependency updates only.

## Test plan

- [x] `bundle exec bundle-audit check --update` — no vulnerabilities found
- [x] `bundle exec rails test` — 820 runs, 2542 assertions, 0 failures
