### PR TITLE
Ignore sync check when auto-merging bot PRs.

### DIFF
--- a/.github/workflows/auto-approve-merge-bot.yml
+++ b/.github/workflows/auto-approve-merge-bot.yml
@@ -61,6 +61,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
           running-workflow-name: 'auto-approve-merge'
+          ignore-checks: sync
 
       - name: Auto-merge PR
         if: steps.check_auto_merge.outputs.auto_merge == 'true'


### PR DESCRIPTION
Dependabot/Renovate PRs do not link to repo issues, so a failing sync job should not block patch/minor auto-merge.