### PR TITLE
Update Brakeman ignore for Rails 8.0 EOL warning.

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -25,12 +25,50 @@
     },
     {
       "warning_type": "Unmaintained Dependency",
+      "warning_code": 122,
+      "fingerprint": "21ab0fe00fdd5899ffc405cff75aadb91b805ee996a614f7e27b08a287e9062d",
+      "check_name": "EOLRails",
+      "message": "Support for Rails 8.0.5.1 ends on 2026-10-07",
+      "file": "Gemfile.lock",
+      "line": 421,
+      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "code": null,
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "Weak",
+      "cwe_id": [
+        1104
+      ],
+      "note": "Temporary until Rails 8.1+ upgrade"
+    },
+    {
+      "warning_type": "Unmaintained Dependency",
+      "warning_code": 122,
+      "fingerprint": "98b26f60d776fd41ee6f088c833725145be9aac2d7c5b33780241c273622db42",
+      "check_name": "EOLRails",
+      "message": "Support for Rails 8.0.5.1 ends on 2026-10-07",
+      "file": "Gemfile.lock",
+      "line": 421,
+      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "code": null,
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "Medium",
+      "cwe_id": [
+        1104
+      ],
+      "note": "Temporary until Rails 8.1+ upgrade; confidence escalates ~30 days before EOL"
+    },
+    {
+      "warning_type": "Unmaintained Dependency",
       "warning_code": 120,
       "fingerprint": "d84924377155b41e094acae7404ec2e521629d86f97b0ff628e3d1b263f8101c",
       "check_name": "EOLRails",
-      "message": "Support for Rails 7.0.8.7 ended on 2025-04-01",
+      "message": "Support for Rails 8.0.5.1 ended on 2026-10-07",
       "file": "Gemfile.lock",
-      "line": 374,
+      "line": 421,
       "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
       "code": null,
       "render_path": null,
@@ -40,8 +78,8 @@
       "cwe_id": [
         1104
       ],
-      "note": "Will update as soon as possible"
+      "note": "Temporary until Rails 8.1+ upgrade; active after EOL date"
     }
   ],
-  "brakeman_version": "7.0.0"
+  "brakeman_version": "7.1.0"
 }


### PR DESCRIPTION
Replace obsolete Rails 7 ignore and cover Weak/Medium/High fingerprints as EOLRails confidence escalates before 2026-10-07.