### PR TITLE
Preserve show-all pagination when sorting the auction list.

### DIFF
--- a/app/helpers/auctions_helper.rb
+++ b/app/helpers/auctions_helper.rb
@@ -1,4 +1,12 @@
 module AuctionsHelper
+  AUCTION_LIST_QUERY_KEYS = %w[sort_by sort_direction domain_name type auction_offer_type].freeze
+
+  def auctions_path_with_list_params(show_all: false)
+    query = request.query_parameters.slice(*AUCTION_LIST_QUERY_KEYS)
+    query = query.merge('show_all' => 'true') if show_all
+    auctions_path(query)
+  end
+
   # MS: need better way about these links. They are external and can change at any time,
   # breaking our website.
   def faq_link

--- a/app/javascript/controllers/table/ordeable_controller.js
+++ b/app/javascript/controllers/table/ordeable_controller.js
@@ -10,7 +10,11 @@ export default class extends Controller {
   }
 
   resortTable(_event) {
-    Turbo.visit('?sort_by=' + this.columnValue + '&sort_direction=' + this.directionValue, { frame: this.frameNameValue });
+    const url = new URL(window.location.href)
+    url.searchParams.set('sort_by', this.columnValue)
+    url.searchParams.set('sort_direction', this.directionValue)
+    url.searchParams.delete('page')
+    Turbo.visit(`${url.pathname}${url.search}`)
   }
 
   directionValueChanged() {

--- a/app/views/auctions/index.html.erb
+++ b/app/views/auctions/index.html.erb
@@ -44,7 +44,7 @@
                             { column: nil, caption: t('auctions.offer_actions'), options: { class: 'u-text-left u-text-center-l' } }] %>
 
     <!-- In the Stimulus controller, I use the Turbo class with frame parameters named 'results' for table sorting. This means that rendering the table with the new sort order should occur within the scope of the turbo_frame_tag with the name "results". For it to work correctly, it's necessary to wrap the table content within this turbo_frame_tag with "results" name. The name "results" is assigned as a value for the orderable Stimulus controller in the table component. -->
-    <%= turbo_frame_tag "results" do %>
+    <%= turbo_frame_tag "results", data: { turbo_action: 'advance' } do %>
 
       <!-- Options attributes are used as table attributes -->
       <%= component 'common/table', header_collection:, options: { class: 'js-table-dt dataTable no-footer' } do %>
@@ -59,16 +59,16 @@
       <% end %>
 
       <%= component 'common/pagy', pagy: @pagy %>
+
+      <div class="u-text-center u-mt-40">
+        <% if params[:show_all] == 'true' %>
+          <%= component 'common/links/link_button', link_title: t('auctions.pagination_list'), href: auctions_path_with_list_params, color: 'ghost', options: { data: { turbo_action: 'advance' } } %>
+        <% else %>
+          <%= component 'common/links/link_button', link_title: t('auctions.all_list'), href: auctions_path_with_list_params(show_all: true), color: 'ghost', options: { data: { turbo_action: 'advance' } } %>
+        <% end %>
+      </div>
     <% end %>
 
-  </div>
-
-  <div class="u-text-center u-mt-40">
-    <% if params[:show_all] == 'true' %>
-      <%= component 'common/links/link_button', link_title: t('auctions.pagination_list'), href: auctions_path, color: 'ghost' %>
-    <% else %>
-      <%= component 'common/links/link_button', link_title: t('auctions.all_list'), href: auctions_path(show_all: 'true'), color: 'ghost' %>
-    <% end %>
   </div>
 </div>
 <!-- Table -- Sortable  -->

--- a/test/controllers/auctions_controller_test.rb
+++ b/test/controllers/auctions_controller_test.rb
@@ -159,8 +159,10 @@ class AuctionsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     auction_domains = css_select('tbody#bids tr.contents td:first-child').map { |e| e.text.strip }
+    expected_domains = Auction.active.search({ sort_by: 'domain_name', sort_direction: 'asc' }).map(&:domain_name)
+
     assert_equal Auction.active.count, auction_domains.size
-    assert_equal auction_domains.sort, auction_domains
+    assert_equal expected_domains, auction_domains
   end
 
   private

--- a/test/controllers/auctions_controller_test.rb
+++ b/test/controllers/auctions_controller_test.rb
@@ -131,4 +131,55 @@ class AuctionsControllerTest < ActionDispatch::IntegrationTest
     
     assert_response :success
   end
+
+  def test_show_all_link_preserves_sort_params
+    get auctions_path, params: { sort_by: 'domain_name', sort_direction: 'asc' }
+
+    assert_response :success
+    query = query_from_link(I18n.t('auctions.all_list'))
+    assert_equal 'true', query['show_all']
+    assert_equal 'domain_name', query['sort_by']
+    assert_equal 'asc', query['sort_direction']
+  end
+
+  def test_paginated_list_link_preserves_sort_params
+    get auctions_path, params: { show_all: 'true', sort_by: 'ends_at', sort_direction: 'desc' }
+
+    assert_response :success
+    query = query_from_link(I18n.t('auctions.pagination_list'))
+    assert_nil query['show_all']
+    assert_equal 'ends_at', query['sort_by']
+    assert_equal 'desc', query['sort_direction']
+  end
+
+  def test_show_all_with_sorting_returns_every_auction_in_sort_order
+    create_extra_active_auctions(16)
+
+    get auctions_path, params: { show_all: 'true', sort_by: 'domain_name', sort_direction: 'asc' }
+
+    assert_response :success
+    auction_domains = css_select('tbody#bids tr.contents td:first-child').map { |e| e.text.strip }
+    assert_equal Auction.active.count, auction_domains.size
+    assert_equal auction_domains.sort, auction_domains
+  end
+
+  private
+
+  def query_from_link(title)
+    link = css_select('a').find { |node| node.text.strip == title }
+    assert_not_nil link, "Expected a link titled #{title}"
+    Rack::Utils.parse_query(URI.parse(link['href']).query.to_s)
+  end
+
+  def create_extra_active_auctions(count)
+    count.times do |i|
+      auction = Auction.new(
+        domain_name: "extra-#{i}.test",
+        starts_at: Time.zone.parse('2000-01-01'),
+        ends_at: Time.zone.parse('2099-12-31')
+      )
+      auction.skip_validation = true
+      auction.save!
+    end
+  end
 end

--- a/test/system/auctions_test.rb
+++ b/test/system/auctions_test.rb
@@ -60,6 +60,39 @@ class AuctionsTest < ApplicationSystemTestCase
     assert_current_path auctions_path + '?show_all=true'
   end
 
+  def test_sorting_keeps_show_all
+    create_extra_active_auctions(16)
+    expected_count = Auction.active.count
+
+    visit('/')
+    click_link_or_button(I18n.t('auctions.all_list'))
+    assert_selector 'tbody#bids tr.contents', count: expected_count
+
+    find('th.sorting', text: I18n.t('auctions.domain_name')).click
+
+    assert_selector 'tbody#bids tr.contents', count: expected_count
+    assert page.has_current_path?(/show_all=true/, url: true)
+    assert page.has_current_path?(/sort_by=domain_name/, url: true)
+  end
+
+  def test_show_all_keeps_existing_sort
+    create_extra_active_auctions(16)
+    expected_count = Auction.active.count
+
+    visit('/')
+    find('thead th.sorting', text: I18n.t('auctions.domain_name')).click
+    assert page.has_current_path?(/sort_by=domain_name/, url: true)
+    page_order = all('tbody#bids tr.contents td:first-child').map { |node| node.text.strip }
+
+    click_link_or_button(I18n.t('auctions.all_list'))
+
+    assert_selector 'tbody#bids tr.contents', count: expected_count
+    all_order = all('tbody#bids tr.contents td:first-child').map { |node| node.text.strip }
+    assert_equal page_order, all_order.first(page_order.size)
+    assert page.has_current_path?(/show_all=true/, url: true)
+    assert page.has_current_path?(/sort_by=domain_name/, url: true)
+  end
+
   # AUTOBIDER ========================================
 
   def test_autobider_available_only_for_english_type_auctions
@@ -124,5 +157,19 @@ class AuctionsTest < ApplicationSystemTestCase
 
     # TODO: Turbo stream not work in test mode
     # assert(page.has_content?(:visible, "#{I18n.t('english_offers.form.autobider')}: #{I18n.t('english_offers.form.yep')}" ))
+  end
+
+  private
+
+  def create_extra_active_auctions(count)
+    count.times do |i|
+      auction = Auction.new(
+        domain_name: "extra-#{i}.test",
+        starts_at: Time.zone.parse('2000-01-01'),
+        ends_at: Time.zone.parse('2099-12-31')
+      )
+      auction.skip_validation = true
+      auction.save!
+    end
   end
 end

--- a/test/system/auctions_test.rb
+++ b/test/system/auctions_test.rb
@@ -66,23 +66,21 @@ class AuctionsTest < ApplicationSystemTestCase
   end
 
   def test_sorting_keeps_show_all
-    create_extra_active_auctions(16)
-    expected_count = Auction.active.count
+    expected_count = setup_extra_active_auctions
 
     visit('/')
     click_link_or_button(I18n.t(ALL_LIST_I18N_KEY))
-    assert_selector AUCTION_ROWS_SELECTOR, count: expected_count
+    assert_all_auction_rows(expected_count)
 
     find('th.sorting', text: I18n.t('auctions.domain_name')).click
 
-    assert_selector AUCTION_ROWS_SELECTOR, count: expected_count
+    assert_all_auction_rows(expected_count)
     assert page.has_current_path?(/show_all=true/, url: true)
     assert page.has_current_path?(DOMAIN_NAME_SORT_QUERY, url: true)
   end
 
   def test_show_all_keeps_existing_sort
-    create_extra_active_auctions(16)
-    expected_count = Auction.active.count
+    expected_count = setup_extra_active_auctions
 
     visit('/')
     find('thead th.sorting', text: I18n.t('auctions.domain_name')).click
@@ -91,7 +89,7 @@ class AuctionsTest < ApplicationSystemTestCase
 
     click_link_or_button(I18n.t(ALL_LIST_I18N_KEY))
 
-    assert_selector AUCTION_ROWS_SELECTOR, count: expected_count
+    assert_all_auction_rows(expected_count)
     all_order = all(AUCTION_DOMAIN_CELLS_SELECTOR).map { |node| node.text.strip }
     assert_equal page_order, all_order.first(page_order.size)
     assert page.has_current_path?(/show_all=true/, url: true)
@@ -165,6 +163,15 @@ class AuctionsTest < ApplicationSystemTestCase
   end
 
   private
+
+  def setup_extra_active_auctions
+    create_extra_active_auctions(16)
+    Auction.active.count
+  end
+
+  def assert_all_auction_rows(count)
+    assert_selector AUCTION_ROWS_SELECTOR, count: count
+  end
 
   def create_extra_active_auctions(count)
     count.times do |i|

--- a/test/system/auctions_test.rb
+++ b/test/system/auctions_test.rb
@@ -2,6 +2,11 @@ require 'application_system_test_case'
 require "test_helper"
 
 class AuctionsTest < ApplicationSystemTestCase
+  AUCTION_ROWS_SELECTOR = 'tbody#bids tr.contents'
+  AUCTION_DOMAIN_CELLS_SELECTOR = "#{AUCTION_ROWS_SELECTOR} td:first-child"
+  ALL_LIST_I18N_KEY = 'auctions.all_list'
+  DOMAIN_NAME_SORT_QUERY = /sort_by=domain_name/
+
   def setup
     super
 
@@ -54,8 +59,8 @@ class AuctionsTest < ApplicationSystemTestCase
 
     visit('/')
 
-    assert(page.has_content?(:visible, I18n.t('auctions.all_list')))
-    click_link_or_button(I18n.t('auctions.all_list'))
+    assert(page.has_content?(:visible, I18n.t(ALL_LIST_I18N_KEY)))
+    click_link_or_button(I18n.t(ALL_LIST_I18N_KEY))
 
     assert_current_path auctions_path + '?show_all=true'
   end
@@ -65,14 +70,14 @@ class AuctionsTest < ApplicationSystemTestCase
     expected_count = Auction.active.count
 
     visit('/')
-    click_link_or_button(I18n.t('auctions.all_list'))
-    assert_selector 'tbody#bids tr.contents', count: expected_count
+    click_link_or_button(I18n.t(ALL_LIST_I18N_KEY))
+    assert_selector AUCTION_ROWS_SELECTOR, count: expected_count
 
     find('th.sorting', text: I18n.t('auctions.domain_name')).click
 
-    assert_selector 'tbody#bids tr.contents', count: expected_count
+    assert_selector AUCTION_ROWS_SELECTOR, count: expected_count
     assert page.has_current_path?(/show_all=true/, url: true)
-    assert page.has_current_path?(/sort_by=domain_name/, url: true)
+    assert page.has_current_path?(DOMAIN_NAME_SORT_QUERY, url: true)
   end
 
   def test_show_all_keeps_existing_sort
@@ -81,16 +86,16 @@ class AuctionsTest < ApplicationSystemTestCase
 
     visit('/')
     find('thead th.sorting', text: I18n.t('auctions.domain_name')).click
-    assert page.has_current_path?(/sort_by=domain_name/, url: true)
-    page_order = all('tbody#bids tr.contents td:first-child').map { |node| node.text.strip }
+    assert page.has_current_path?(DOMAIN_NAME_SORT_QUERY, url: true)
+    page_order = all(AUCTION_DOMAIN_CELLS_SELECTOR).map { |node| node.text.strip }
 
-    click_link_or_button(I18n.t('auctions.all_list'))
+    click_link_or_button(I18n.t(ALL_LIST_I18N_KEY))
 
-    assert_selector 'tbody#bids tr.contents', count: expected_count
-    all_order = all('tbody#bids tr.contents td:first-child').map { |node| node.text.strip }
+    assert_selector AUCTION_ROWS_SELECTOR, count: expected_count
+    all_order = all(AUCTION_DOMAIN_CELLS_SELECTOR).map { |node| node.text.strip }
     assert_equal page_order, all_order.first(page_order.size)
     assert page.has_current_path?(/show_all=true/, url: true)
-    assert page.has_current_path?(/sort_by=domain_name/, url: true)
+    assert page.has_current_path?(DOMAIN_NAME_SORT_QUERY, url: true)
   end
 
   # AUTOBIDER ========================================


### PR DESCRIPTION
close #1623

Sorting and the show-all toggle were overwriting each other's query params, so the list fell back to 15 rows after a sort.

Now when auctions are sorted on list view(by domain name, auction type or bid) and after that list view changed from 15 -> all,
then sorted order remains as selected by user.

Same logic works both ways. If user selects previously 'list all auctions' and then uses sort, then list view still displays all auctions(in sorted order by selected value).