### PR TITLE
Hide participant menu links until the user is signed in

### DIFF
--- a/app/components/common/header/component.rb
+++ b/app/components/common/header/component.rb
@@ -62,12 +62,15 @@ module Common
       end
 
       def regular_menu_list_items
-        items = [{ name: t(:auctions_name), path: auctions_path },
-                 { name: t(:my_invoices), path: invoices_path },
-                 { name: t(:my_offers), path: offers_path },
-                 { name: t(:my_wishlist), path: wishlist_items_path }]
+        items = [{ name: t(:auctions_name), path: auctions_path }]
 
-        items.insert(1, { name: t(:profile), path: user_path(current_user&.uuid) }) if user_signed_in?
+        if user_signed_in?
+          items.insert(1, { name: t(:profile), path: user_path(current_user&.uuid) })
+          items.insert(2, { name: t(:my_invoices), path: invoices_path })
+          items.insert(3, { name: t(:my_offers), path: offers_path })
+          items.insert(4, { name: t(:my_wishlist), path: wishlist_items_path })
+        end
+
         items
       end
     end

--- a/test/components/common/header_test.rb
+++ b/test/components/common/header_test.rb
@@ -1,0 +1,43 @@
+require 'test_helper'
+
+class Common::Header::ComponentTest < ViewComponent::TestCase
+  def setup
+    Common::Header::Notification::Component.define_method(:user_signed_in?) { false }
+  end
+
+  def teardown
+    Common::Header::Notification::Component.remove_method(:user_signed_in?)
+  end
+
+  def test_guest_sees_only_auctions_in_submenu
+    render_header(user: nil)
+
+    assert_selector '.submenu a', text: I18n.t(:auctions_name)
+    assert_no_selector '.submenu a', text: I18n.t(:profile)
+    assert_no_selector '.submenu a', text: I18n.t(:my_invoices)
+    assert_no_selector '.submenu a', text: I18n.t(:my_offers)
+    assert_no_selector '.submenu a', text: I18n.t(:my_wishlist)
+  end
+
+  def test_signed_in_participant_sees_account_links_in_submenu
+    render_header(user: users(:participant))
+
+    assert_selector '.submenu a', text: I18n.t(:auctions_name)
+    assert_selector '.submenu a', text: I18n.t(:profile)
+    assert_selector '.submenu a', text: I18n.t(:my_invoices)
+    assert_selector '.submenu a', text: I18n.t(:my_offers)
+    assert_selector '.submenu a', text: I18n.t(:my_wishlist)
+  end
+
+  private
+
+  def render_header(user:)
+    component = Common::Header::Component.new(notifications: nil)
+    component.define_singleton_method(:user_signed_in?) { user.present? }
+    component.define_singleton_method(:current_user) { user }
+
+    with_request_url '/' do
+      render_inline(component)
+    end
+  end
+end


### PR DESCRIPTION
close #1624

This update will hide menu items:
* AUCTIONS
* INVOICES
* OFFERS
* WISHLIST

until the participant has signed in