### PR TITLE
Ruby version tags -> bookworm

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -2,7 +2,7 @@
 
 # Make sure RUBY_VERSION matches the Ruby version in .ruby-version and Gemfile
 ARG RUBY_VERSION=3.4.9
-FROM registry.docker.com/library/ruby:$RUBY_VERSION-bullseye AS base
+FROM registry.docker.com/library/ruby:$RUBY_VERSION-bookworm AS base
 
 # Rails app lives here
 WORKDIR /opt/webapps/app

--- a/Dockerfile.staging
+++ b/Dockerfile.staging
@@ -2,7 +2,7 @@
 
 # Make sure RUBY_VERSION matches the Ruby version in .ruby-version and Gemfile
 ARG RUBY_VERSION=3.4.9
-FROM registry.docker.com/library/ruby:$RUBY_VERSION-bullseye AS base
+FROM registry.docker.com/library/ruby:$RUBY_VERSION-bookworm AS base
 
 # Rails app lives here
 WORKDIR /opt/webapps/app

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -2,7 +2,7 @@
 
 # Make sure RUBY_VERSION matches the Ruby version in .ruby-version and Gemfile
 ARG RUBY_VERSION=3.4.9
-FROM registry.docker.com/library/ruby:$RUBY_VERSION-bullseye AS base
+FROM registry.docker.com/library/ruby:$RUBY_VERSION-bookworm AS base
 
 # Rails app lives here
 WORKDIR /opt/webapps/app


### PR DESCRIPTION
Change dockerfile tags accordingly to Ruby version 3.4.9
ruby:$RUBY_VERSION-bullseye → ruby:$RUBY_VERSION-bookworm